### PR TITLE
Backend events routes

### DIFF
--- a/new-site/packages/backend/cmd/api/main.go
+++ b/new-site/packages/backend/cmd/api/main.go
@@ -45,7 +45,7 @@ func main() {
 	r.PUT("/users/:id", userHandler.UpdateUser)
 	r.DELETE("/users/:id", userHandler.DeleteUser)
 	r.POST("/login", authHandler.LoginHandler)
-	r.GET("/events", eventHandler.GetAllEvents)
+	r.GET("/events", eventHandler.GetEvents)
 	r.GET("/event/:eventName/:date", eventHandler.GetEventByNameAndDate)
 
 	// Rotas Protegidas (Exigem Autenticação)

--- a/new-site/packages/backend/cmd/api/main.go
+++ b/new-site/packages/backend/cmd/api/main.go
@@ -45,6 +45,7 @@ func main() {
 	r.PUT("/users/:id", userHandler.UpdateUser)
 	r.DELETE("/users/:id", userHandler.DeleteUser)
 	r.POST("/login", authHandler.LoginHandler)
+	r.GET("/events", eventHandler.GetAllEvents)
 	r.GET("/event/:eventName/:date", eventHandler.GetEventByNameAndDate)
 
 	// Rotas Protegidas (Exigem Autenticação)

--- a/new-site/packages/backend/cmd/api/main.go
+++ b/new-site/packages/backend/cmd/api/main.go
@@ -45,6 +45,7 @@ func main() {
 	r.PUT("/users/:id", userHandler.UpdateUser)
 	r.DELETE("/users/:id", userHandler.DeleteUser)
 	r.POST("/login", authHandler.LoginHandler)
+	r.GET("/event/:eventName/:date", eventHandler.GetEventByNameAndDate)
 
 	// Rotas Protegidas (Exigem Autenticação)
 	authRoutes := r.Group("/api")

--- a/new-site/packages/backend/cmd/api/main.go
+++ b/new-site/packages/backend/cmd/api/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"backend/internal/database"
+	"backend/internal/event"
 	"backend/internal/auth"
 	"backend/internal/middleware"
 	"backend/internal/providers"
@@ -16,7 +17,7 @@ func main() {
 		panic("Failed to connect to database: " + errDB.Error())
 	}
 
-	err := db.AutoMigrate(&user.User{})
+	err := db.AutoMigrate(&user.User{}, &event.Event{})
 	if err != nil {
 		panic("Failed to migrate database: " + err.Error())
 	}

--- a/new-site/packages/backend/cmd/api/main.go
+++ b/new-site/packages/backend/cmd/api/main.go
@@ -56,6 +56,7 @@ func main() {
 	adminRoutes := r.Group("/admin")
 	// TODO: admin middleware
 	adminRoutes.POST("/events", eventHandler.CreateEvent)
+	adminRoutes.PUT("/events/:eventName/:date", eventHandler.UpdateEventByNameAndDate)
 	adminRoutes.DELETE("/events/:eventName/:date", eventHandler.DeleteEventByNameAndDate)
 
 	r.Run(":4000")

--- a/new-site/packages/backend/cmd/api/main.go
+++ b/new-site/packages/backend/cmd/api/main.go
@@ -56,6 +56,7 @@ func main() {
 	adminRoutes := r.Group("/admin")
 	// TODO: admin middleware
 	adminRoutes.POST("/events", eventHandler.CreateEvent)
+	adminRoutes.DELETE("/events/:eventName/:date", eventHandler.DeleteEventByNameAndDate)
 
 	r.Run(":4000")
 }

--- a/new-site/packages/backend/cmd/api/main.go
+++ b/new-site/packages/backend/cmd/api/main.go
@@ -29,6 +29,9 @@ func main() {
 	userRepo := user.NewUserRepository(db)
 	userService := user.NewUserService(userRepo, passwordProvider)
 	userHandler := user.NewUserHandler(userService)
+	eventRepo := event.NewEventRepository(db)
+	eventService := event.NewEventService(eventRepo)
+	eventHandler := event.NewEventHandler(eventService)
 
 	authService := auth.NewAuthService(userRepo, passwordProvider, jwtProvider)
 	authHandler := auth.NewAuthHandler(authService)
@@ -47,6 +50,11 @@ func main() {
 	authRoutes := r.Group("/api")
 	authRoutes.Use(middleware.AuthMiddleware(jwtProvider))
 	authRoutes.GET("/profile", authHandler.ProfileHandler())
+
+	// Rotas de admin
+	adminRoutes := r.Group("/admin")
+	// TODO: admin middleware
+	adminRoutes.POST("/events", eventHandler.CreateEvent)
 
 	r.Run(":4000")
 }

--- a/new-site/packages/backend/internal/event/DOCS.md
+++ b/new-site/packages/backend/internal/event/DOCS.md
@@ -1,0 +1,246 @@
+# Events API
+
+Documentacao das rotas de eventos do backend.
+
+## Entidade Event
+
+A tabela de eventos é composta por:
+
+- `Name`: Nome do evento.
+- `DateTime`: Data e hora do evento.
+- `Type`: Tipo do evento.
+- `Location`: Local do evento.
+- `Description`: Descricao do evento.
+- `HasAttendance`: Indica se o evento tem presenca.
+
+## Formato de data
+
+- O backend espera datas em **RFC3339** (ex.: `2026-07-10T14:00:00Z`).
+- Nas rotas com `:date`, envie a data no mesmo formato.
+
+---
+
+## 1) Criar evento [ADMIN]
+
+- **Metodo**: `POST`
+- **Rota**: `/admin/events`
+- **Body (JSON)**:
+
+```json
+{
+  "name": "Workshop A",
+  "date_time": "2026-07-10T14:00:00Z",
+  "type": "Workshop",
+  "location": "Auditorio A",
+  "description": "Introducao a Computacao",
+  "has_attendance": true
+}
+```
+
+Resposta de sucesso (`201`):
+
+```json
+{
+  "message": "Evento criado com sucesso!",
+  "event": {
+    "name": "Workshop A",
+    "date_time": "2026-07-10T14:00:00Z",
+    "type": "Workshop",
+    "location": "Auditorio A",
+    "description": "Introducao a Computacao",
+    "has_attendance": true
+  }
+}
+```
+
+Erros comuns:
+
+- `400`: `{"error":"Dados inválidos"}`
+- `500`: `{"error":"..."}`
+
+---
+
+## 2) Listar eventos [PUBLICO]
+
+- **Metodo**: `GET`
+- **Rota**: `/events`
+- **Query params**:
+  - `page` (opcional, default `1`, minimo `1`)
+  - `limit` (opcional, default `10`, minimo `1`)
+  - `sort_by` (opcional, default `date_time`)
+  - `sort_order` (opcional, default `asc`)
+  - `search_by` (opcional, usado com `search_value`)
+  - `search_value` (opcional, usado com `search_by`)
+
+### Campos permitidos em `sort_by`
+
+- `name`
+- `date_time`
+- `type`
+- `location`
+- `description`
+- `has_attendance`
+
+### Valores permitidos em `sort_order`
+
+- `asc`
+- `desc`
+
+### Busca (`search_by` + `search_value`)
+
+Deve ser usado **um campo por vez**.
+
+Campos permitidos em `search_by`:
+
+- `name`
+- `type`
+- `location`
+- `description`
+- `date_time` (valor em RFC3339)
+- `has_attendance` (`true` ou `false`)
+
+Exemplo:
+
+`GET /events?page=1&limit=10&sort_by=name&sort_order=desc&search_by=type&search_value=Workshop`
+
+Resposta de sucesso (`200`):
+
+```json
+{
+  "page": 1,
+  "limit": 10,
+  "sort_by": "name",
+  "sort_order": "desc",
+  "search_by": "type",
+  "search_value": "Workshop",
+  "total_records": 120,
+  "filtered_records": 14,
+  "events": [
+    {
+      "name": "Workshop A",
+      "date_time": "2026-07-10T14:00:00Z",
+      "type": "Workshop",
+      "location": "Auditorio A",
+      "description": "Introducao a Computacao",
+      "has_attendance": true
+    }
+  ]
+}
+```
+
+Erros comuns (`400`):
+
+- `{"error":"Parâmetro 'page' inválido"}`
+- `{"error":"Parâmetro 'limit' inválido"}`
+- `{"error":"invalid sort_by parameter"}`
+- `{"error":"invalid sort_order parameter"}`
+- `{"error":"search_by and search_value must be provided together"}`
+- `{"error":"invalid search_by parameter"}`
+- `{"error":"invalid search_value for date_time, use RFC3339"}`
+- `{"error":"invalid search_value for has_attendance"}`
+
+---
+
+## 3) Buscar evento especifico [PUBLICO]
+
+- **Metodo**: `GET`
+- **Rota**: `/event/:eventName/:date`
+
+Exemplo:
+
+`GET /event/Workshop%20A/2026-07-10T14:00:00Z`
+
+Resposta de sucesso (`200`):
+
+```json
+{
+  "name": "Workshop A",
+  "date_time": "2026-07-10T14:00:00Z",
+  "type": "Workshop",
+  "location": "Auditorio A",
+  "description": "Introducao a Computacao",
+  "has_attendance": true
+}
+```
+
+Erros comuns:
+
+- `400`: `{"error":"Data inválida. Use o formato RFC3339"}`
+- `404`: `{"error":"Evento não encontrado"}`
+- `500`: `{"error":"Erro interno do servidor"}`
+
+---
+
+## 4) Atualizar evento [ADMIN]
+
+- **Metodo**: `PUT`
+- **Rota**: `/admin/events/:eventName/:date`
+- **Body (JSON)**: mesmo formato da criacao
+
+Exemplo:
+
+`PUT /admin/events/Workshop%20A/2026-07-10T14:00:00Z`
+
+```json
+{
+  "name": "Workshop Golang",
+  "date_time": "2026-07-10T16:00:00Z",
+  "type": "Workshop",
+  "location": "Auditorio B",
+  "description": "Conteudo atualizado",
+  "has_attendance": true
+}
+```
+
+Resposta de sucesso (`200`):
+
+```json
+{
+  "message": "Evento atualizado com sucesso!",
+  "event": {
+    "name": "Workshop Golang",
+    "date_time": "2026-07-10T16:00:00Z",
+    "type": "Workshop",
+    "location": "Auditorio B",
+    "description": "Conteudo atualizado",
+    "has_attendance": true
+  }
+}
+```
+
+Erros comuns:
+
+- `400`: `{"error":"Dados inválidos"}` ou `{"error":"Data inválida. Use o formato RFC3339"}`
+- `404`: `{"error":"Evento não encontrado"}`
+- `500`: `{"error":"Erro interno do servidor"}`
+
+---
+
+## 5) Deletar evento [ADMIN]
+
+- **Metodo**: `DELETE`
+- **Rota**: `/admin/events/:eventName/:date`
+
+Exemplo:
+
+`DELETE /admin/events/Workshop%20A/2026-07-10T14:00:00Z`
+
+Resposta de sucesso (`200`):
+
+```json
+{
+  "message": "Evento removido com sucesso!"
+}
+```
+
+Erros comuns:
+
+- `400`: `{"error":"Data inválida. Use o formato RFC3339"}`
+- `404`: `{"error":"Evento não encontrado"}`
+- `500`: `{"error":"Erro interno do servidor"}`
+
+---
+
+## Observacoes
+
+- As rotas em `/admin/...` estao agrupadas como admin no router.

--- a/new-site/packages/backend/internal/event/handler.go
+++ b/new-site/packages/backend/internal/event/handler.go
@@ -1,0 +1,32 @@
+package event
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type EventHandler struct {
+	eventService EventService
+}
+
+func NewEventHandler(eventService EventService) *EventHandler {
+	return &EventHandler{eventService: eventService}
+}
+
+func (h *EventHandler) CreateEvent(c *gin.Context) {
+	var request CreateEventRequest
+
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Dados inválidos"})
+		return
+	}
+
+	event, err := h.eventService.CreateEvent(request)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{"message": "Evento criado com sucesso!", "event": event})
+}

--- a/new-site/packages/backend/internal/event/handler.go
+++ b/new-site/packages/backend/internal/event/handler.go
@@ -54,3 +54,26 @@ func (h *EventHandler) GetEventByNameAndDate(c *gin.Context) {
 
 	c.JSON(http.StatusOK, event)
 }
+
+func (h *EventHandler) DeleteEventByNameAndDate(c *gin.Context) {
+	name := c.Param("eventName")
+	date := c.Param("date")
+
+	err := h.eventService.DeleteEventByNameAndDate(name, date)
+	if err != nil {
+		if errors.Is(err, ErrInvalidEventDate) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Data inválida. Use o formato RFC3339"})
+			return
+		}
+
+		if errors.Is(err, ErrEventNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Evento não encontrado"})
+			return
+		}
+
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erro interno do servidor"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Evento removido com sucesso!"})
+}

--- a/new-site/packages/backend/internal/event/handler.go
+++ b/new-site/packages/backend/internal/event/handler.go
@@ -108,9 +108,13 @@ func (h *EventHandler) UpdateEventByNameAndDate(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Evento atualizado com sucesso!", "event": event})
 }
 
-func (h *EventHandler) GetAllEvents(c *gin.Context) {
+func (h *EventHandler) GetEvents(c *gin.Context) {
 	page := 1
 	limit := 10
+	sortBy := c.DefaultQuery("sort_by", "date_time")
+	sortOrder := c.DefaultQuery("sort_order", "asc")
+	searchBy := c.Query("search_by")
+	searchValue := c.Query("search_value")
 
 	if pageQuery := c.Query("page"); pageQuery != "" {
 		parsedPage, err := strconv.Atoi(pageQuery)
@@ -130,15 +134,21 @@ func (h *EventHandler) GetAllEvents(c *gin.Context) {
 		limit = parsedLimit
 	}
 
-	events, err := h.eventService.GetAllEvents(page, limit)
+	result, err := h.eventService.GetEvents(page, limit, sortBy, sortOrder, searchBy, searchValue)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"page":   page,
-		"limit":  limit,
-		"events": events,
+		"page":             page,
+		"limit":            limit,
+		"sort_by":          sortBy,
+		"sort_order":       sortOrder,
+		"search_by":        searchBy,
+		"search_value":     searchValue,
+		"total_records":    result.TotalRecords,
+		"filtered_records": result.FilteredRecords,
+		"events":           result.Events,
 	})
 }

--- a/new-site/packages/backend/internal/event/handler.go
+++ b/new-site/packages/backend/internal/event/handler.go
@@ -3,6 +3,7 @@ package event
 import (
 	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 )
@@ -105,4 +106,39 @@ func (h *EventHandler) UpdateEventByNameAndDate(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "Evento atualizado com sucesso!", "event": event})
+}
+
+func (h *EventHandler) GetAllEvents(c *gin.Context) {
+	page := 1
+	limit := 10
+
+	if pageQuery := c.Query("page"); pageQuery != "" {
+		parsedPage, err := strconv.Atoi(pageQuery)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Parâmetro 'page' inválido"})
+			return
+		}
+		page = parsedPage
+	}
+
+	if limitQuery := c.Query("limit"); limitQuery != "" {
+		parsedLimit, err := strconv.Atoi(limitQuery)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Parâmetro 'limit' inválido"})
+			return
+		}
+		limit = parsedLimit
+	}
+
+	events, err := h.eventService.GetAllEvents(page, limit)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"page":   page,
+		"limit":  limit,
+		"events": events,
+	})
 }

--- a/new-site/packages/backend/internal/event/handler.go
+++ b/new-site/packages/backend/internal/event/handler.go
@@ -77,3 +77,32 @@ func (h *EventHandler) DeleteEventByNameAndDate(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"message": "Evento removido com sucesso!"})
 }
+
+func (h *EventHandler) UpdateEventByNameAndDate(c *gin.Context) {
+	name := c.Param("eventName")
+	date := c.Param("date")
+
+	var request UpdateEventRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Dados inválidos"})
+		return
+	}
+
+	event, err := h.eventService.UpdateEventByNameAndDate(name, date, request)
+	if err != nil {
+		if errors.Is(err, ErrInvalidEventDate) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Data inválida. Use o formato RFC3339"})
+			return
+		}
+
+		if errors.Is(err, ErrEventNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Evento não encontrado"})
+			return
+		}
+
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erro interno do servidor"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Evento atualizado com sucesso!", "event": event})
+}

--- a/new-site/packages/backend/internal/event/handler.go
+++ b/new-site/packages/backend/internal/event/handler.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -29,4 +30,27 @@ func (h *EventHandler) CreateEvent(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusCreated, gin.H{"message": "Evento criado com sucesso!", "event": event})
+}
+
+func (h *EventHandler) GetEventByNameAndDate(c *gin.Context) {
+	name := c.Param("eventName")
+	date := c.Param("date")
+
+	event, err := h.eventService.GetEventByNameAndDate(name, date)
+	if err != nil {
+		if errors.Is(err, ErrInvalidEventDate) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Data inválida. Use o formato RFC3339"})
+			return
+		}
+
+		if errors.Is(err, ErrEventNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Evento não encontrado"})
+			return
+		}
+
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erro interno do servidor"})
+		return
+	}
+
+	c.JSON(http.StatusOK, event)
 }

--- a/new-site/packages/backend/internal/event/model.go
+++ b/new-site/packages/backend/internal/event/model.go
@@ -10,3 +10,12 @@ type Event struct {
 	Description   string    `gorm:"type:text"`
 	HasAttendance bool
 }
+
+type CreateEventRequest struct {
+	Name          string    `json:"name" binding:"required,max=200"`
+	DateTime      time.Time `json:"date_time" binding:"required"`
+	Type          string    `json:"type" binding:"omitempty,max=50"`
+	Location      string    `json:"location"`
+	Description   string    `json:"description"`
+	HasAttendance bool      `json:"has_attendance"`
+}

--- a/new-site/packages/backend/internal/event/model.go
+++ b/new-site/packages/backend/internal/event/model.go
@@ -28,3 +28,18 @@ type UpdateEventRequest struct {
 	Description   string    `json:"description"`
 	HasAttendance bool      `json:"has_attendance"`
 }
+
+type EventListQuery struct {
+	Limit       int
+	Offset      int
+	SortBy      string
+	SortOrder   string
+	SearchBy    string
+	SearchValue string
+}
+
+type EventListResult struct {
+	Events           []Event
+	TotalRecords     int64
+	FilteredRecords  int64
+}

--- a/new-site/packages/backend/internal/event/model.go
+++ b/new-site/packages/backend/internal/event/model.go
@@ -19,3 +19,12 @@ type CreateEventRequest struct {
 	Description   string    `json:"description"`
 	HasAttendance bool      `json:"has_attendance"`
 }
+
+type UpdateEventRequest struct {
+	Name          string    `json:"name" binding:"required,max=200"`
+	DateTime      time.Time `json:"date_time" binding:"required"`
+	Type          string    `json:"type" binding:"omitempty,max=50"`
+	Location      string    `json:"location"`
+	Description   string    `json:"description"`
+	HasAttendance bool      `json:"has_attendance"`
+}

--- a/new-site/packages/backend/internal/event/model.go
+++ b/new-site/packages/backend/internal/event/model.go
@@ -3,12 +3,12 @@ package event
 import "time"
 
 type Event struct {
-	Name          string    `gorm:"size:200;primaryKey;not null"`
-	DateTime      time.Time `gorm:"type:timestamptz;primaryKey;not null"`
-	Type          string    `gorm:"size:50"`
-	Location      string
-	Description   string    `gorm:"type:text"`
-	HasAttendance bool
+	Name          string    `gorm:"size:200;primaryKey;not null" json:"name"`
+	DateTime      time.Time `gorm:"type:timestamptz;primaryKey;not null" json:"date_time"`
+	Type          string    `gorm:"size:50" json:"type"`
+	Location      string    `json:"location"`
+	Description   string    `gorm:"type:text" json:"description"`
+	HasAttendance bool      `json:"has_attendance"`
 }
 
 type CreateEventRequest struct {
@@ -39,7 +39,7 @@ type EventListQuery struct {
 }
 
 type EventListResult struct {
-	Events           []Event
-	TotalRecords     int64
-	FilteredRecords  int64
+	Events          []Event `json:"events"`
+	TotalRecords    int64   `json:"total_records"`
+	FilteredRecords int64   `json:"filtered_records"`
 }

--- a/new-site/packages/backend/internal/event/model.go
+++ b/new-site/packages/backend/internal/event/model.go
@@ -1,0 +1,12 @@
+package event
+
+import "time"
+
+type Event struct {
+	Name          string    `gorm:"size:200;primaryKey;not null"`
+	DateTime      time.Time `gorm:"type:timestamptz;primaryKey;not null"`
+	Type          string    `gorm:"size:50"`
+	Location      string
+	Description   string    `gorm:"type:text"`
+	HasAttendance bool
+}

--- a/new-site/packages/backend/internal/event/repository.go
+++ b/new-site/packages/backend/internal/event/repository.go
@@ -1,7 +1,10 @@
 package event
 
 import (
+	"fmt"
+	"strings"
 	"time"
+	"slices"
 
 	"gorm.io/gorm"
 )
@@ -11,7 +14,7 @@ type EventRepository interface {
 	GetByNameAndDateTime(name string, dateTime time.Time) (*Event, error)
 	DeleteByNameAndDateTime(name string, dateTime time.Time) error
 	UpdateByNameAndDateTime(name string, dateTime time.Time, event *Event) error
-	GetAll(limit int, offset int) ([]Event, error)
+	GetEvents(query EventListQuery) (*EventListResult, error)
 }
 
 type eventRepository struct {
@@ -72,12 +75,85 @@ func (r *eventRepository) UpdateByNameAndDateTime(name string, dateTime time.Tim
 	return nil
 }
 
-func (r *eventRepository) GetAll(limit int, offset int) ([]Event, error) {
+func applySearchFilter(dbQuery *gorm.DB, query EventListQuery) *gorm.DB {
+	if query.SearchBy == "" || query.SearchValue == "" {
+		return dbQuery
+	}
+
+	switch query.SearchBy {
+	case "name":
+		return dbQuery.Where("name ILIKE ?", "%"+query.SearchValue+"%")
+	case "type":
+		return dbQuery.Where("type ILIKE ?", "%"+query.SearchValue+"%")
+	case "location":
+		return dbQuery.Where("location ILIKE ?", "%"+query.SearchValue+"%")
+	case "description":
+		return dbQuery.Where("description ILIKE ?", "%"+query.SearchValue+"%")
+	case "date_time":
+		return dbQuery.Where("date_time = ?", query.SearchValue)
+	case "has_attendance":
+		return dbQuery.Where("has_attendance = ?", query.SearchValue)
+	default:
+		return dbQuery
+	}
+}
+
+func resolveSortClause(sortBy string, sortOrder string) (string, error) {
+	allowedSortFields := []string{
+		"name",
+		"date_time",
+		"type",
+		"location",
+		"description",
+		"has_attendance",
+	}
+
+	field := strings.ToLower(sortBy)
+	isAllowedField := slices.Contains(allowedSortFields, field)
+	if !isAllowedField {
+		return "", fmt.Errorf("invalid sort field")
+	}
+
+	if !isAllowedField {
+		return "", fmt.Errorf("invalid sort field")
+	}
+
+	order := strings.ToLower(sortOrder)
+	if order != "asc" && order != "desc" {
+		return "", fmt.Errorf("invalid sort order")
+	}
+
+	return field + " " + order, nil
+}
+
+func (r *eventRepository) GetEvents(query EventListQuery) (*EventListResult, error) {
 	var events []Event
-	err := r.db.Order("date_time asc").Limit(limit).Offset(offset).Find(&events).Error
+	var totalRecords int64
+	var filteredRecords int64
+
+	sortClause, err := resolveSortClause(query.SortBy, query.SortOrder)
 	if err != nil {
 		return nil, err
 	}
 
-	return events, nil
+	if err := r.db.Model(&Event{}).Count(&totalRecords).Error; err != nil {
+		return nil, err
+	}
+
+	filteredQuery := applySearchFilter(r.db.Model(&Event{}), query)
+	if err := filteredQuery.Count(&filteredRecords).Error; err != nil {
+		return nil, err
+	}
+
+	dataQuery := applySearchFilter(r.db.Model(&Event{}), query)
+	err = dataQuery.Order(sortClause).Limit(query.Limit).Offset(query.Offset).Find(&events).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return &EventListResult{
+		Events:          events,
+		TotalRecords:    totalRecords,
+		FilteredRecords: filteredRecords,
+	}, nil
 }

--- a/new-site/packages/backend/internal/event/repository.go
+++ b/new-site/packages/backend/internal/event/repository.go
@@ -10,6 +10,7 @@ type EventRepository interface {
 	Create(event *Event) error
 	GetByNameAndDateTime(name string, dateTime time.Time) (*Event, error)
 	DeleteByNameAndDateTime(name string, dateTime time.Time) error
+	UpdateByNameAndDateTime(name string, dateTime time.Time, event *Event) error
 }
 
 type eventRepository struct {
@@ -36,6 +37,29 @@ func (r *eventRepository) GetByNameAndDateTime(name string, dateTime time.Time) 
 
 func (r *eventRepository) DeleteByNameAndDateTime(name string, dateTime time.Time) error {
 	result := r.db.Where("name = ? AND date_time = ?", name, dateTime).Delete(&Event{})
+	if result.Error != nil {
+		return result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+
+	return nil
+}
+
+func (r *eventRepository) UpdateByNameAndDateTime(name string, dateTime time.Time, event *Event) error {
+	result := r.db.Model(&Event{}).
+		Where("name = ? AND date_time = ?", name, dateTime).
+		Updates(map[string]interface{}{
+			"name":           event.Name,
+			"date_time":      event.DateTime,
+			"type":           event.Type,
+			"location":       event.Location,
+			"description":    event.Description,
+			"has_attendance": event.HasAttendance,
+		})
+
 	if result.Error != nil {
 		return result.Error
 	}

--- a/new-site/packages/backend/internal/event/repository.go
+++ b/new-site/packages/backend/internal/event/repository.go
@@ -114,10 +114,6 @@ func resolveSortClause(sortBy string, sortOrder string) (string, error) {
 		return "", fmt.Errorf("invalid sort field")
 	}
 
-	if !isAllowedField {
-		return "", fmt.Errorf("invalid sort field")
-	}
-
 	order := strings.ToLower(sortOrder)
 	if order != "asc" && order != "desc" {
 		return "", fmt.Errorf("invalid sort order")

--- a/new-site/packages/backend/internal/event/repository.go
+++ b/new-site/packages/backend/internal/event/repository.go
@@ -1,0 +1,19 @@
+package event
+
+import "gorm.io/gorm"
+
+type EventRepository interface {
+	Create(event *Event) error
+}
+
+type eventRepository struct {
+	db *gorm.DB
+}
+
+func NewEventRepository(db *gorm.DB) EventRepository {
+	return &eventRepository{db: db}
+}
+
+func (r *eventRepository) Create(event *Event) error {
+	return r.db.Create(event).Error
+}

--- a/new-site/packages/backend/internal/event/repository.go
+++ b/new-site/packages/backend/internal/event/repository.go
@@ -1,9 +1,14 @@
 package event
 
-import "gorm.io/gorm"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 type EventRepository interface {
 	Create(event *Event) error
+	GetByNameAndDateTime(name string, dateTime time.Time) (*Event, error)
 }
 
 type eventRepository struct {
@@ -16,4 +21,14 @@ func NewEventRepository(db *gorm.DB) EventRepository {
 
 func (r *eventRepository) Create(event *Event) error {
 	return r.db.Create(event).Error
+}
+
+func (r *eventRepository) GetByNameAndDateTime(name string, dateTime time.Time) (*Event, error) {
+	var event Event
+	err := r.db.Where("name = ? AND date_time = ?", name, dateTime).First(&event).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return &event, nil
 }

--- a/new-site/packages/backend/internal/event/repository.go
+++ b/new-site/packages/backend/internal/event/repository.go
@@ -9,6 +9,7 @@ import (
 type EventRepository interface {
 	Create(event *Event) error
 	GetByNameAndDateTime(name string, dateTime time.Time) (*Event, error)
+	DeleteByNameAndDateTime(name string, dateTime time.Time) error
 }
 
 type eventRepository struct {
@@ -31,4 +32,17 @@ func (r *eventRepository) GetByNameAndDateTime(name string, dateTime time.Time) 
 	}
 
 	return &event, nil
+}
+
+func (r *eventRepository) DeleteByNameAndDateTime(name string, dateTime time.Time) error {
+	result := r.db.Where("name = ? AND date_time = ?", name, dateTime).Delete(&Event{})
+	if result.Error != nil {
+		return result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+
+	return nil
 }

--- a/new-site/packages/backend/internal/event/repository.go
+++ b/new-site/packages/backend/internal/event/repository.go
@@ -11,6 +11,7 @@ type EventRepository interface {
 	GetByNameAndDateTime(name string, dateTime time.Time) (*Event, error)
 	DeleteByNameAndDateTime(name string, dateTime time.Time) error
 	UpdateByNameAndDateTime(name string, dateTime time.Time, event *Event) error
+	GetAll(limit int, offset int) ([]Event, error)
 }
 
 type eventRepository struct {
@@ -69,4 +70,14 @@ func (r *eventRepository) UpdateByNameAndDateTime(name string, dateTime time.Tim
 	}
 
 	return nil
+}
+
+func (r *eventRepository) GetAll(limit int, offset int) ([]Event, error) {
+	var events []Event
+	err := r.db.Order("date_time asc").Limit(limit).Offset(offset).Find(&events).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return events, nil
 }

--- a/new-site/packages/backend/internal/event/service.go
+++ b/new-site/packages/backend/internal/event/service.go
@@ -15,6 +15,7 @@ var (
 type EventService interface {
 	CreateEvent(request CreateEventRequest) (*Event, error)
 	GetEventByNameAndDate(name string, date string) (*Event, error)
+	DeleteEventByNameAndDate(name string, date string) error
 }
 
 type eventService struct {
@@ -57,4 +58,21 @@ func (s *eventService) GetEventByNameAndDate(name string, date string) (*Event, 
 	}
 
 	return event, nil
+}
+
+func (s *eventService) DeleteEventByNameAndDate(name string, date string) error {
+	dateTime, err := time.Parse(time.RFC3339, date)
+	if err != nil {
+		return ErrInvalidEventDate
+	}
+
+	err = s.repo.DeleteByNameAndDateTime(name, dateTime)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrEventNotFound
+		}
+		return err
+	}
+
+	return nil
 }

--- a/new-site/packages/backend/internal/event/service.go
+++ b/new-site/packages/backend/internal/event/service.go
@@ -1,0 +1,30 @@
+package event
+
+type EventService interface {
+	CreateEvent(request CreateEventRequest) (*Event, error)
+}
+
+type eventService struct {
+	repo EventRepository
+}
+
+func NewEventService(repo EventRepository) EventService {
+	return &eventService{repo: repo}
+}
+
+func (s *eventService) CreateEvent(request CreateEventRequest) (*Event, error) {
+	newEvent := Event{
+		Name:          request.Name,
+		DateTime:      request.DateTime,
+		Type:          request.Type,
+		Location:      request.Location,
+		Description:   request.Description,
+		HasAttendance: request.HasAttendance,
+	}
+
+	if err := s.repo.Create(&newEvent); err != nil {
+		return nil, err
+	}
+
+	return &newEvent, nil
+}

--- a/new-site/packages/backend/internal/event/service.go
+++ b/new-site/packages/backend/internal/event/service.go
@@ -3,6 +3,8 @@ package event
 import (
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -18,7 +20,7 @@ type EventService interface {
 	GetEventByNameAndDate(name string, date string) (*Event, error)
 	DeleteEventByNameAndDate(name string, date string) error
 	UpdateEventByNameAndDate(name string, date string, request UpdateEventRequest) (*Event, error)
-	GetAllEvents(page int, limit int) ([]Event, error)
+	GetEvents(page int, limit int, sortBy string, sortOrder string, searchBy string, searchValue string) (*EventListResult, error)
 }
 
 type eventService struct {
@@ -106,7 +108,7 @@ func (s *eventService) UpdateEventByNameAndDate(name string, date string, reques
 	return &event, nil
 }
 
-func (s *eventService) GetAllEvents(page int, limit int) ([]Event, error) {
+func (s *eventService) GetEvents(page int, limit int, sortBy string, sortOrder string, searchBy string, searchValue string) (*EventListResult, error) {
 	if page < 1 {
 		return nil, fmt.Errorf("page must be greater than 0")
 	}
@@ -115,6 +117,78 @@ func (s *eventService) GetAllEvents(page int, limit int) ([]Event, error) {
 		return nil, fmt.Errorf("limit must be greater than 0")
 	}
 
+	if sortBy == "" {
+		sortBy = "date_time"
+	}
+
+	if sortOrder == "" {
+		sortOrder = "asc"
+	}
+
+	sortBy = strings.ToLower(sortBy)
+	sortOrder = strings.ToLower(sortOrder)
+
+	allowedSortFields := map[string]bool{
+		"name":           true,
+		"date_time":      true,
+		"type":           true,
+		"location":       true,
+		"description":    true,
+		"has_attendance": true,
+	}
+
+	if !allowedSortFields[sortBy] {
+		return nil, fmt.Errorf("invalid sort_by parameter")
+	}
+
+	if sortOrder != "asc" && sortOrder != "desc" {
+		return nil, fmt.Errorf("invalid sort_order parameter")
+	}
+
+	if (searchBy == "" && searchValue != "") || (searchBy != "" && searchValue == "") {
+		return nil, fmt.Errorf("search_by and search_value must be provided together")
+	}
+
+	if searchBy != "" {
+		searchBy = strings.ToLower(searchBy)
+
+		allowedSearchFields := map[string]bool{
+			"name":           true,
+			"type":           true,
+			"location":       true,
+			"description":    true,
+			"date_time":      true,
+			"has_attendance": true,
+		}
+
+		if !allowedSearchFields[searchBy] {
+			return nil, fmt.Errorf("invalid search_by parameter")
+		}
+
+		if searchBy == "date_time" {
+			parsedDateTime, err := time.Parse(time.RFC3339, searchValue)
+			if err != nil {
+				return nil, fmt.Errorf("invalid search_value for date_time, use RFC3339")
+			}
+			searchValue = parsedDateTime.Format(time.RFC3339)
+		}
+
+		if searchBy == "has_attendance" {
+			if _, err := strconv.ParseBool(searchValue); err != nil {
+				return nil, fmt.Errorf("invalid search_value for has_attendance")
+			}
+		}
+	}
+
 	offset := (page - 1) * limit
-	return s.repo.GetAll(limit, offset)
+	query := EventListQuery{
+		Limit:       limit,
+		Offset:      offset,
+		SortBy:      sortBy,
+		SortOrder:   sortOrder,
+		SearchBy:    searchBy,
+		SearchValue: searchValue,
+	}
+
+	return s.repo.GetEvents(query)
 }

--- a/new-site/packages/backend/internal/event/service.go
+++ b/new-site/packages/backend/internal/event/service.go
@@ -1,7 +1,20 @@
 package event
 
+import (
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+var (
+	ErrInvalidEventDate = errors.New("invalid event date format")
+	ErrEventNotFound    = errors.New("event not found")
+)
+
 type EventService interface {
 	CreateEvent(request CreateEventRequest) (*Event, error)
+	GetEventByNameAndDate(name string, date string) (*Event, error)
 }
 
 type eventService struct {
@@ -27,4 +40,21 @@ func (s *eventService) CreateEvent(request CreateEventRequest) (*Event, error) {
 	}
 
 	return &newEvent, nil
+}
+
+func (s *eventService) GetEventByNameAndDate(name string, date string) (*Event, error) {
+	dateTime, err := time.Parse(time.RFC3339, date)
+	if err != nil {
+		return nil, ErrInvalidEventDate
+	}
+
+	event, err := s.repo.GetByNameAndDateTime(name, dateTime)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrEventNotFound
+		}
+		return nil, err
+	}
+
+	return event, nil
 }

--- a/new-site/packages/backend/internal/event/service.go
+++ b/new-site/packages/backend/internal/event/service.go
@@ -16,6 +16,7 @@ type EventService interface {
 	CreateEvent(request CreateEventRequest) (*Event, error)
 	GetEventByNameAndDate(name string, date string) (*Event, error)
 	DeleteEventByNameAndDate(name string, date string) error
+	UpdateEventByNameAndDate(name string, date string, request UpdateEventRequest) (*Event, error)
 }
 
 type eventService struct {
@@ -75,4 +76,30 @@ func (s *eventService) DeleteEventByNameAndDate(name string, date string) error 
 	}
 
 	return nil
+}
+
+func (s *eventService) UpdateEventByNameAndDate(name string, date string, request UpdateEventRequest) (*Event, error) {
+	originalDateTime, err := time.Parse(time.RFC3339, date)
+	if err != nil {
+		return nil, ErrInvalidEventDate
+	}
+
+	event := Event{
+		Name:          request.Name,
+		DateTime:      request.DateTime,
+		Type:          request.Type,
+		Location:      request.Location,
+		Description:   request.Description,
+		HasAttendance: request.HasAttendance,
+	}
+
+	err = s.repo.UpdateByNameAndDateTime(name, originalDateTime, &event)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrEventNotFound
+		}
+		return nil, err
+	}
+
+	return &event, nil
 }

--- a/new-site/packages/backend/internal/event/service.go
+++ b/new-site/packages/backend/internal/event/service.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"gorm.io/gorm"
@@ -17,6 +18,7 @@ type EventService interface {
 	GetEventByNameAndDate(name string, date string) (*Event, error)
 	DeleteEventByNameAndDate(name string, date string) error
 	UpdateEventByNameAndDate(name string, date string, request UpdateEventRequest) (*Event, error)
+	GetAllEvents(page int, limit int) ([]Event, error)
 }
 
 type eventService struct {
@@ -102,4 +104,17 @@ func (s *eventService) UpdateEventByNameAndDate(name string, date string, reques
 	}
 
 	return &event, nil
+}
+
+func (s *eventService) GetAllEvents(page int, limit int) ([]Event, error) {
+	if page < 1 {
+		return nil, fmt.Errorf("page must be greater than 0")
+	}
+
+	if limit < 1 {
+		return nil, fmt.Errorf("limit must be greater than 0")
+	}
+
+	offset := (page - 1) * limit
+	return s.repo.GetAll(limit, offset)
 }


### PR DESCRIPTION
Implementação da entidade eventos com separação por camadas (model, handler, service, repository), mantendo o mesmo padrão arquitetural já adotado em usuário/autenticação.
Foram criadas rotas públicas e de admin (backoffice) para gerenciamento completo dos eventos:
- `GET /events`: listagem pública com paginação (page, limit), ordenação (sort_by, sort_order) e busca por campo único (search_by, search_value).
- `GET /event/:eventName/:date`: consulta pública de evento específico por chave composta (name + date_time).
- `POST /admin/events`: criação de evento.
- `PUT /admin/events/:eventName/:date`: atualização de evento específico.
- `DELETE /admin/events/:eventName/:date`: remoção de evento específico.
Também foi adicionada validação de parâmetros de listagem e reforço de segurança nas queries dinâmicas (filtros e ordenação com campos permitidos), além do retorno de metadados de listagem (total_records e filtered_records).
Para detalhes de payloads, exemplos de entrada/saída e formatos aceitos, ver `internal/event/DOCS.md`.