### PR TITLE
Feat: change botao patrocinador, with explicit confirm

### DIFF
--- a/new-site/packages/front-site/src/pages/Login/index.tsx
+++ b/new-site/packages/front-site/src/pages/Login/index.tsx
@@ -61,7 +61,6 @@ export default function LoginPage(): ReactElement {
     const [hasPapfe, setHasPapfe] = useState(false);
     const [papfeFile, setPapfeFile] = useState<File | null>(null);
     const [querCracha, setQuerCracha] = useState(false);
-    // null = ainda não respondeu;
     const [autorizaCompartilhamento, setAutorizaCompartilhamento] = useState<boolean | null>(null);
     const [confirmandoRecusa, setConfirmandoRecusa] = useState(false);
 

--- a/new-site/packages/front-site/src/pages/Login/index.tsx
+++ b/new-site/packages/front-site/src/pages/Login/index.tsx
@@ -61,7 +61,9 @@ export default function LoginPage(): ReactElement {
     const [hasPapfe, setHasPapfe] = useState(false);
     const [papfeFile, setPapfeFile] = useState<File | null>(null);
     const [querCracha, setQuerCracha] = useState(false);
-    const [autorizaCompartilhamento, setAutorizaCompartilhamento] = useState(false);
+    // null = ainda não respondeu;
+    const [autorizaCompartilhamento, setAutorizaCompartilhamento] = useState<boolean | null>(null);
+    const [confirmandoRecusa, setConfirmandoRecusa] = useState(false);
 
     const [forgotPasswordMode, setForgotPasswordMode] = useState(false);
     const [forgotEmail, setForgotEmail] = useState("");
@@ -109,7 +111,8 @@ export default function LoginPage(): ReactElement {
         setEducation(""); setProfession(""); setLinkedin(""); setTelegram("");
         setHasPapfe(false); setPapfeFile(null); setHasDisability(false); setDisabilities([]);
         setQuerCracha(false);
-        setAutorizaCompartilhamento(false);
+        setAutorizaCompartilhamento(null);
+        setConfirmandoRecusa(false);
     }, []);
 
     useEffect(() => {
@@ -169,16 +172,17 @@ export default function LoginPage(): ReactElement {
             if (!education) return "Selecione sua formação.";
             if (hasDisability && disabilities.length === 0) return "Adicione ao menos uma deficiência ou desmarque a opção.";
             if (hasPapfe && !papfeFile) return "O comprovante PAPFE é obrigatório.";
+            if (autorizaCompartilhamento === null) return "Responda se podemos compartilhar seus dados com os patrocinadores.";
         }
         return null;
-    }, [email, password, confirmPassword, isLogin, name, age, city, gender, education, hasDisability, disabilities, hasPapfe, papfeFile]);
+    }, [email, password, confirmPassword, isLogin, name, age, city, gender, education, hasDisability, disabilities, hasPapfe, papfeFile, autorizaCompartilhamento]);
 
     const register = useCallback(async () => {
         try {
             const response = await authAPI.register(
                 name, email, password, Number(age), gender, city, education,
                 hasPapfe, hasDisability ? disabilities : [], querCracha,
-                autorizaCompartilhamento,
+                autorizaCompartilhamento === true,
                 profession, linkedin, telegram, papfeFile,
             );
             showNotification(response.message || "Registro realizado!", "success");
@@ -480,17 +484,86 @@ export default function LoginPage(): ReactElement {
                                 </span>
                             </label>
 
-                            <label className="flex items-start gap-2 pt-2 text-sm cursor-pointer">
-                                <input 
-                                    type="checkbox" 
-                                    checked={autorizaCompartilhamento} 
-                                    onChange={(e) => setAutorizaCompartilhamento(e.target.checked)} 
-                                    className="w-4 h-4 mt-0.5 shrink-0 rounded accent-semcompMidDarkBlue cursor-pointer" 
-                                />
-                                <span>
-                                    Autorizo o compartilhamento das minhas informações com os patrocinadores do evento
-                                </span>
-                            </label>
+                            {/* Compartilhamento com patrocinadores: resposta obrigatória, sem opção pré-marcada.
+                                Recusar não bloqueia o cadastro, apenas pede uma confirmação no lugar do campo. */}
+                            <div data-share-field className="relative pt-2">
+                                <div
+                                    className={`grid transition-all duration-300 ease-out ${confirmandoRecusa ? "grid-rows-[0fr] opacity-0 pointer-events-none" : "grid-rows-[1fr] opacity-100"}`}
+                                    aria-hidden={confirmandoRecusa}
+                                >
+                                    <div className="overflow-hidden">
+                                        <div className="text-sm font-medium mb-1">
+                                            Podemos compartilhar seus dados de contato com os patrocinadores do evento? <span className="opacity-70">*</span>
+                                        </div>
+                                        <div className="text-xs opacity-70 mb-2">
+                                            Eles usam essas informações para divulgar vagas de estágio e emprego.
+                                            <br />
+                                            Sua resposta não afeta sua inscrição.
+                                        </div>
+                                        <div role="radiogroup" aria-label="Compartilhar dados com os patrocinadores" className="flex gap-2">
+                                            {([true, false] as const).map((valor) => (
+                                                <button
+                                                    key={String(valor)}
+                                                    type="button"
+                                                    role="radio"
+                                                    aria-checked={autorizaCompartilhamento === valor}
+                                                    onClick={(e) => {
+                                                        if (valor) {
+                                                            setAutorizaCompartilhamento(true);
+                                                            return;
+                                                        }
+                                                        // a recusa só é aplicada depois de confirmada
+                                                        const campo = e.currentTarget.closest("[data-share-field]");
+                                                        setConfirmandoRecusa(true);
+                                                        setTimeout(() => campo?.scrollIntoView({ behavior: "smooth", block: "nearest" }), 300);
+                                                    }}
+                                                    className={`flex-1 py-2 rounded-lg border text-sm transition-all ${
+                                                        autorizaCompartilhamento === valor
+                                                            ? "bg-white border-white text-semcompDarkBlue font-bold"
+                                                            : "border-gray-400/40 hover:bg-white/10"
+                                                    }`}
+                                                >
+                                                    {valor ? "Sim" : "Não"}
+                                                </button>
+                                            ))}
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div
+                                    className={`grid transition-all duration-300 ease-out ${confirmandoRecusa ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0 pointer-events-none"}`}
+                                    aria-hidden={!confirmandoRecusa}
+                                >
+                                    <div className="overflow-hidden">
+                                        <div className="rounded-lg border border-red-600 bg-red-600/10 p-3 text-xs text-white">
+                                            <p className="mb-2.5 leading-relaxed">
+                                                Sem o compartilhamento, os patrocinadores não recebem seu contato para divulgar vagas de estágio e emprego.
+                                                <br />
+                                                Confirma que não quer compartilhar?
+                                            </p>
+                                            <div className="flex gap-2">
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setConfirmandoRecusa(false)}
+                                                    className="flex-1 py-2 rounded-md border border-gray-400/40 text-white font-semibold hover:brightness-110 transition-all"
+                                                >
+                                                    Voltar
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => {
+                                                        setAutorizaCompartilhamento(false);
+                                                        setConfirmandoRecusa(false);
+                                                    }}
+                                                    className="flex-1 py-2 rounded-md bg-red-600 text-white font-semibold hover:brightness-110 transition-all"
+                                                >
+                                                    Confirmar
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </>
                     )}
                 </div>


### PR DESCRIPTION
## O que muda

O campo de compartilhamento de dados com os patrocinadores deixa de ser um checkbox e passa a ser uma pergunta obrigatória de Sim/Não, sem opção pré-selecionada. 
Ao escolher "Não", o campo se transforma numa caixa de confirmação no próprio lugar; a recusa só é aplicada depois de confirmada. 
**Responder "Não" não bloqueia o cadastro.**

Arquivo alterado: `new-site/packages/front-site/src/pages/Login/index.tsx`

## Por quê

O checkbox tinha um problema de ambiguidade: não dava para distinguir quem decidiu não compartilhar de quem simplesmente não viu o campo. Como hipótese, parte significativa das pessoas podem não ler a última linha do forms
Com a pergunta obrigatória, toda resposta gravada é uma escolha que a pessoa efetivamente fez. (alem de possivelmente melhorar a conversão)

## Decisões de implementação

**Estado com três valores em vez de booleano.**
`autorizaCompartilhamento` passou de `boolean` para `boolean | null`, onde `null` significa "ainda não respondeu". 
Isso é o que permite o `validate()` barrar o envio enquanto não houver resposta. Pelo mesmo motivo o `resetForm` volta o campo para `null` e não para `false`.

A API não mudou. O `authAPI.register` continua recebendo `boolean`, agora via `autorizaCompartilhamento === true`, então não há alteração de contrato nem no backend.

**`setConfirmandoRecusa(false)` dentro do `resetForm`.** 
O `confirmandoRecusa` controla qual dos dois painéis está visível, e o `resetForm` é passado como `hook` do `SegmentedControl`, ou seja, roda toda vez que a pessoa alterna entre ENTRAR e CADASTRAR. 

**Botões com `role="radio"` em vez de `<input type="radio">`.** 
O `formContent` é montado uma vez e renderizado três vezes (desktop, tablet e mobile ficam simultaneamente no DOM, alternados por CSS) **[Padrão do projeto]**. Três inputs com o mesmo `name` formariam um único grupo de rádio compartilhado entre os layouts, um desmarcando o outro. Os botões com `role="radio"` e `aria-checked` mantêm a semântica de grupo para leitores de tela sem depender do `name`, e o estado visual fica inteiramente derivado do React.

**Transição em CSS (`grid-rows-[0fr] → [1fr]`) em vez de altura medida por ref.** 
A troca entre a pergunta e a confirmação muda a altura do bloco, e sem transição isso empurra o botão "Criar conta" de forma brusca no meio da interação. 
A abordagem usual seria medir a altura com `ref` e animar, mas as três cópias do formulário compartilhariam a mesma ref e a medição cairia num elemento escondido, com altura zero. O truque de `grid-template-rows` com `overflow-hidden` anima a altura em CSS puro, sem medição, e funciona igual nos três layouts.

**Rolagem após expandir.** 
Se o campo estiver colado na borda inferior da área rolável, a caixa de confirmação nasce cortada. 
Depois da transição, um `scrollIntoView({ block: "nearest" })` rola o mínimo necessário (nada se a caixa já estiver visível). O elemento é obtido a partir do `e.currentTarget.closest("[data-share-field]")` do clique, o que garante que a rolagem aconteça na cópia visível do formulário, e não em uma das escondidas.

## Como testei

clique nos botões nas 3 formas (web,tablet,celular) seguindo os fluxos esperados.
Video do teste: 

https://github.com/user-attachments/assets/a12eea87-b539-4c08-884e-f3fe3802c259

