### PR TITLE
feat: adiciona motivo de ter negado justificativas

### DIFF
--- a/new-site/packages/backend/cmd/api/main.go
+++ b/new-site/packages/backend/cmd/api/main.go
@@ -210,6 +210,7 @@ func main() {
 	authRoutes.GET("/profile", authHandler.ProfileHandler())
 	authRoutes.GET("/verify-email", userHandler.VerifyEmailHandler)
 	authRoutes.PUT("/papfe-document", userHandler.UpdatePapfeDocument)
+	authRoutes.GET("/papfe-document", userHandler.GetMyPapfeDocument)
 	authRoutes.POST("/absence-justifications", absenceJustificationHandler.CreateAbsenceJustification)
 	authRoutes.GET("/absence-justifications/mine", absenceJustificationHandler.GetMine)
 	authRoutes.GET("/absence-justifications/:id/attachment", absenceJustificationHandler.GetOwnAttachment)

--- a/new-site/packages/backend/docs/docs.go
+++ b/new-site/packages/backend/docs/docs.go
@@ -15,6 +15,178 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/admin/absence-justifications": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna todas as justificativas de ausência cadastradas",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Justificativas de Ausência"
+                ],
+                "summary": "Lista justificativas de ausência",
+                "responses": {
+                    "200": {
+                        "description": "Lista de justificativas de ausência",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/absence-justifications/{id}": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Aprova, rejeita, marca como documento inválido ou volta para análise uma justificativa de ausência. Ao negar, o campo rejection_reason é obrigatório e só persiste nesse status.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Justificativas de Ausência"
+                ],
+                "summary": "Atualiza o status de uma justificativa de ausência",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID da justificativa",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Novo status",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/absenceJustification.UpdateStatusRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Status atualizado com sucesso!",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Dados inválidos",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Justificativa não encontrada",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/absence-justifications/{id}/attachment": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna o arquivo comprobatório de uma justificativa de ausência específica",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "Justificativas de Ausência"
+                ],
+                "summary": "Obtém o anexo de uma justificativa de ausência",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID da justificativa",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Arquivo anexo",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "ID inválido",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Justificativa não encontrada",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/admin/events": {
             "post": {
                 "security": [
@@ -283,6 +455,41 @@ const docTemplate = `{
                             "additionalProperties": {
                                 "type": "string"
                             }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/papfe-documents": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna metadados de todos os comprovantes PAPFE cadastrados",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Usuários (Participantes)"
+                ],
+                "summary": "Lista comprovantes PAPFE",
+                "responses": {
+                    "200": {
+                        "description": "Lista de comprovantes PAPFE",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "500": {
@@ -1446,6 +1653,217 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/sponsors": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sponsors Backoffice"
+                ],
+                "summary": "Lista todos os patrocinadores (admin)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sponsors Backoffice"
+                ],
+                "summary": "Cria patrocinador (admin)",
+                "responses": {}
+            }
+        },
+        "/admin/sponsors/{cnpj}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sponsors Backoffice"
+                ],
+                "summary": "Busca patrocinador por CNPJ (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CNPJ do patrocinador",
+                        "name": "cnpj",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sponsor.Sponsor"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sponsors Backoffice"
+                ],
+                "summary": "Atualiza patrocinador (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CNPJ do patrocinador",
+                        "name": "cnpj",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {}
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "Sponsors Backoffice"
+                ],
+                "summary": "Remove patrocinador (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CNPJ do patrocinador",
+                        "name": "cnpj",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {}
+            }
+        },
+        "/admin/sponsors/{cnpj}/packages": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "Sponsors Backoffice"
+                ],
+                "summary": "Lista pacotes de patrocinador (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CNPJ do patrocinador",
+                        "name": "cnpj",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Filtrar por ano",
+                        "name": "year",
+                        "in": "query"
+                    }
+                ],
+                "responses": {}
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "Sponsors Backoffice"
+                ],
+                "summary": "Adiciona pacote de patrocinador (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CNPJ do patrocinador",
+                        "name": "cnpj",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {}
+            }
+        },
+        "/admin/sponsors/{cnpj}/packages/{year}/{package}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "Sponsors Backoffice"
+                ],
+                "summary": "Remove pacote de patrocinador (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CNPJ do patrocinador",
+                        "name": "cnpj",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Ano do pacote",
+                        "name": "year",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Nome do pacote",
+                        "name": "package",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {}
+            }
+        },
         "/admin/users": {
             "get": {
                 "security": [
@@ -1719,6 +2137,143 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Usuário não existe",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/users/{id}/papfe-document": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna o arquivo do comprovante PAPFE de um usuário específico",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "Usuários (Participantes)"
+                ],
+                "summary": "Obtém comprovante PAPFE de um usuário",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID do usuário",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Arquivo do comprovante PAPFE",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "ID inválido",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Usuário ou comprovante não encontrado",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/users/{id}/papfe-document/approval": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Altera o status de aprovação do comprovante PAPFE de um usuário. Ao rejeitar, o campo rejection_reason é obrigatório e só persiste nesse status.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Usuários (Participantes)"
+                ],
+                "summary": "Aprova/rejeita comprovante PAPFE",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID do usuário",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Status de aprovação",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/user.PapfeApprovalRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Status de aprovação atualizado com sucesso!",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Dados inválidos",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Usuário ou comprovante não encontrado",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -2031,6 +2586,388 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Usuário não existe ou erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/absence-justifications": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Registra a justificativa de ausência (referente à SEMCOMP como um todo) do usuário autenticado, com anexo comprobatório. Cada usuário só pode ter uma justificativa.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Justificativas de Ausência"
+                ],
+                "summary": "Envia a justificativa de ausência do usuário autenticado",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Motivo da ausência",
+                        "name": "reason",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "Comprovante (PDF/JPEG/PNG/WebP, máx 10MB)",
+                        "name": "attachment",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Justificativa enviada com sucesso!",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Dados inválidos",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Justificativa já enviada",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/absence-justifications/mine": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna a justificativa de ausência enviada pelo usuário autenticado, se houver",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Justificativas de Ausência"
+                ],
+                "summary": "Obtém a justificativa de ausência do usuário autenticado",
+                "responses": {
+                    "200": {
+                        "description": "Justificativa do usuário",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Nenhuma justificativa enviada",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/absence-justifications/{id}": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Edita o motivo e, opcionalmente, substitui o anexo da justificativa do usuário autenticado. Permitido apenas quando o status for \"em_analise\" ou \"documento_invalido\"; editar reenvia a justificativa para análise.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Justificativas de Ausência"
+                ],
+                "summary": "Atualiza a justificativa de ausência do usuário autenticado",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID da justificativa",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Motivo da ausência",
+                        "name": "reason",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "Novo comprovante (opcional, substitui o anterior)",
+                        "name": "attachment",
+                        "in": "formData"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Justificativa atualizada com sucesso!",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Dados inválidos",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Justificativa não pertence ao usuário",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Justificativa não encontrada",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Justificativa já aprovada ou negada",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/absence-justifications/{id}/attachment": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna o arquivo comprobatório da justificativa do usuário autenticado",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "Justificativas de Ausência"
+                ],
+                "summary": "Obtém o anexo da própria justificativa de ausência",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID da justificativa",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Arquivo anexo",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "ID inválido",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Justificativa não pertence ao usuário",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Justificativa não encontrada",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/papfe-document": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna os metadados do comprovante PAPFE do usuário autenticado (sem os bytes do arquivo), incluindo o motivo da rejeição quando houver",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Usuários (Participantes)"
+                ],
+                "summary": "Obtém o próprio comprovante PAPFE",
+                "responses": {
+                    "200": {
+                        "description": "Comprovante PAPFE do usuário",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Nenhum comprovante enviado",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Atualiza o comprovante PAPFE do usuário autenticado. Aceita multipart/form-data.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Usuários (Participantes)"
+                ],
+                "summary": "Atualiza comprovante PAPFE",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "Comprovante PAPFE (PDF/JPEG/PNG/WebP, máx 10MB)",
+                        "name": "papfe_document",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Comprovante PAPFE atualizado com sucesso!",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Dados inválidos",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -2485,6 +3422,82 @@ const docTemplate = `{
                 }
             }
         },
+        "/sponsors": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sponsors"
+                ],
+                "summary": "Lista patrocinadores públicos",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/sponsor.PublicSponsor"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/sponsors/{cnpj}/click": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sponsors"
+                ],
+                "summary": "Registra clique em patrocinador",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CNPJ do patrocinador (14 dígitos)",
+                        "name": "cnpj",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/stats": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Stats"
+                ],
+                "summary": "Retorna estatísticas do site",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "integer",
+                                "format": "int64"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/verify-email": {
             "post": {
                 "description": "Valida o token de verificação enviado por e-mail e ativa a conta",
@@ -2539,9 +3552,43 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/visit": {
+            "post": {
+                "tags": [
+                    "Stats"
+                ],
+                "summary": "Registra visita à home page",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "absenceJustification.UpdateStatusRequest": {
+            "type": "object",
+            "required": [
+                "status"
+            ],
+            "properties": {
+                "rejection_reason": {
+                    "description": "Obrigatório quando Status=\"negado\"; ignorado/limpo nos demais status.",
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "em_analise",
+                        "aprovado",
+                        "negado",
+                        "documento_invalido"
+                    ]
+                }
+            }
+        },
         "auth.LoginUserRequest": {
             "type": "object",
             "required": [
@@ -3024,6 +4071,78 @@ const docTemplate = `{
                             "$ref": "#/definitions/product.ProductType"
                         }
                     ]
+                }
+            }
+        },
+        "sponsor.PublicSponsor": {
+            "type": "object",
+            "properties": {
+                "cnpj": {
+                    "type": "string"
+                },
+                "logo": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "website": {
+                    "type": "string"
+                }
+            }
+        },
+        "sponsor.Sponsor": {
+            "type": "object",
+            "properties": {
+                "clicks": {
+                    "type": "integer"
+                },
+                "cnpj": {
+                    "type": "string"
+                },
+                "logo": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "packages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sponsor.SponsorPackage"
+                    }
+                },
+                "website": {
+                    "type": "string"
+                }
+            }
+        },
+        "sponsor.SponsorPackage": {
+            "type": "object",
+            "properties": {
+                "package": {
+                    "type": "string"
+                },
+                "sponsor_cnpj": {
+                    "type": "string"
+                },
+                "year": {
+                    "type": "integer"
+                }
+            }
+        },
+        "user.PapfeApprovalRequest": {
+            "type": "object",
+            "required": [
+                "approved"
+            ],
+            "properties": {
+                "approved": {
+                    "type": "boolean"
+                },
+                "rejection_reason": {
+                    "description": "Obrigatório quando Approved=false (rejeição).",
+                    "type": "string"
                 }
             }
         },

--- a/new-site/packages/backend/docs/swagger.json
+++ b/new-site/packages/backend/docs/swagger.json
@@ -9,6 +9,178 @@
     "host": "localhost:4000",
     "basePath": "/",
     "paths": {
+        "/admin/absence-justifications": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna todas as justificativas de ausência cadastradas",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Justificativas de Ausência"
+                ],
+                "summary": "Lista justificativas de ausência",
+                "responses": {
+                    "200": {
+                        "description": "Lista de justificativas de ausência",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/absence-justifications/{id}": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Aprova, rejeita, marca como documento inválido ou volta para análise uma justificativa de ausência. Ao negar, o campo rejection_reason é obrigatório e só persiste nesse status.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Justificativas de Ausência"
+                ],
+                "summary": "Atualiza o status de uma justificativa de ausência",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID da justificativa",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Novo status",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/absenceJustification.UpdateStatusRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Status atualizado com sucesso!",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Dados inválidos",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Justificativa não encontrada",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/absence-justifications/{id}/attachment": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna o arquivo comprobatório de uma justificativa de ausência específica",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "Justificativas de Ausência"
+                ],
+                "summary": "Obtém o anexo de uma justificativa de ausência",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID da justificativa",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Arquivo anexo",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "ID inválido",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Justificativa não encontrada",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/admin/events": {
             "post": {
                 "security": [
@@ -277,6 +449,41 @@
                             "additionalProperties": {
                                 "type": "string"
                             }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/papfe-documents": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna metadados de todos os comprovantes PAPFE cadastrados",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Usuários (Participantes)"
+                ],
+                "summary": "Lista comprovantes PAPFE",
+                "responses": {
+                    "200": {
+                        "description": "Lista de comprovantes PAPFE",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "500": {
@@ -1440,6 +1647,217 @@
                 }
             }
         },
+        "/admin/sponsors": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sponsors Backoffice"
+                ],
+                "summary": "Lista todos os patrocinadores (admin)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sponsors Backoffice"
+                ],
+                "summary": "Cria patrocinador (admin)",
+                "responses": {}
+            }
+        },
+        "/admin/sponsors/{cnpj}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sponsors Backoffice"
+                ],
+                "summary": "Busca patrocinador por CNPJ (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CNPJ do patrocinador",
+                        "name": "cnpj",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sponsor.Sponsor"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sponsors Backoffice"
+                ],
+                "summary": "Atualiza patrocinador (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CNPJ do patrocinador",
+                        "name": "cnpj",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {}
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "Sponsors Backoffice"
+                ],
+                "summary": "Remove patrocinador (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CNPJ do patrocinador",
+                        "name": "cnpj",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {}
+            }
+        },
+        "/admin/sponsors/{cnpj}/packages": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "Sponsors Backoffice"
+                ],
+                "summary": "Lista pacotes de patrocinador (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CNPJ do patrocinador",
+                        "name": "cnpj",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Filtrar por ano",
+                        "name": "year",
+                        "in": "query"
+                    }
+                ],
+                "responses": {}
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "Sponsors Backoffice"
+                ],
+                "summary": "Adiciona pacote de patrocinador (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CNPJ do patrocinador",
+                        "name": "cnpj",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {}
+            }
+        },
+        "/admin/sponsors/{cnpj}/packages/{year}/{package}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "Sponsors Backoffice"
+                ],
+                "summary": "Remove pacote de patrocinador (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CNPJ do patrocinador",
+                        "name": "cnpj",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Ano do pacote",
+                        "name": "year",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Nome do pacote",
+                        "name": "package",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {}
+            }
+        },
         "/admin/users": {
             "get": {
                 "security": [
@@ -1713,6 +2131,143 @@
                     },
                     "404": {
                         "description": "Usuário não existe",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/users/{id}/papfe-document": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna o arquivo do comprovante PAPFE de um usuário específico",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "Usuários (Participantes)"
+                ],
+                "summary": "Obtém comprovante PAPFE de um usuário",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID do usuário",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Arquivo do comprovante PAPFE",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "ID inválido",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Usuário ou comprovante não encontrado",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/users/{id}/papfe-document/approval": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Altera o status de aprovação do comprovante PAPFE de um usuário. Ao rejeitar, o campo rejection_reason é obrigatório e só persiste nesse status.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Usuários (Participantes)"
+                ],
+                "summary": "Aprova/rejeita comprovante PAPFE",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID do usuário",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Status de aprovação",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/user.PapfeApprovalRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Status de aprovação atualizado com sucesso!",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Dados inválidos",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Usuário ou comprovante não encontrado",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -2025,6 +2580,388 @@
                     },
                     "500": {
                         "description": "Usuário não existe ou erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/absence-justifications": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Registra a justificativa de ausência (referente à SEMCOMP como um todo) do usuário autenticado, com anexo comprobatório. Cada usuário só pode ter uma justificativa.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Justificativas de Ausência"
+                ],
+                "summary": "Envia a justificativa de ausência do usuário autenticado",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Motivo da ausência",
+                        "name": "reason",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "Comprovante (PDF/JPEG/PNG/WebP, máx 10MB)",
+                        "name": "attachment",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Justificativa enviada com sucesso!",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Dados inválidos",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Justificativa já enviada",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/absence-justifications/mine": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna a justificativa de ausência enviada pelo usuário autenticado, se houver",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Justificativas de Ausência"
+                ],
+                "summary": "Obtém a justificativa de ausência do usuário autenticado",
+                "responses": {
+                    "200": {
+                        "description": "Justificativa do usuário",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Nenhuma justificativa enviada",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/absence-justifications/{id}": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Edita o motivo e, opcionalmente, substitui o anexo da justificativa do usuário autenticado. Permitido apenas quando o status for \"em_analise\" ou \"documento_invalido\"; editar reenvia a justificativa para análise.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Justificativas de Ausência"
+                ],
+                "summary": "Atualiza a justificativa de ausência do usuário autenticado",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID da justificativa",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Motivo da ausência",
+                        "name": "reason",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "Novo comprovante (opcional, substitui o anterior)",
+                        "name": "attachment",
+                        "in": "formData"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Justificativa atualizada com sucesso!",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Dados inválidos",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Justificativa não pertence ao usuário",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Justificativa não encontrada",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Justificativa já aprovada ou negada",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/absence-justifications/{id}/attachment": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna o arquivo comprobatório da justificativa do usuário autenticado",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "Justificativas de Ausência"
+                ],
+                "summary": "Obtém o anexo da própria justificativa de ausência",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID da justificativa",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Arquivo anexo",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "ID inválido",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Justificativa não pertence ao usuário",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Justificativa não encontrada",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/papfe-document": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna os metadados do comprovante PAPFE do usuário autenticado (sem os bytes do arquivo), incluindo o motivo da rejeição quando houver",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Usuários (Participantes)"
+                ],
+                "summary": "Obtém o próprio comprovante PAPFE",
+                "responses": {
+                    "200": {
+                        "description": "Comprovante PAPFE do usuário",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Nenhum comprovante enviado",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Atualiza o comprovante PAPFE do usuário autenticado. Aceita multipart/form-data.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Usuários (Participantes)"
+                ],
+                "summary": "Atualiza comprovante PAPFE",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "Comprovante PAPFE (PDF/JPEG/PNG/WebP, máx 10MB)",
+                        "name": "papfe_document",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Comprovante PAPFE atualizado com sucesso!",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Dados inválidos",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -2479,6 +3416,82 @@
                 }
             }
         },
+        "/sponsors": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sponsors"
+                ],
+                "summary": "Lista patrocinadores públicos",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/sponsor.PublicSponsor"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/sponsors/{cnpj}/click": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sponsors"
+                ],
+                "summary": "Registra clique em patrocinador",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CNPJ do patrocinador (14 dígitos)",
+                        "name": "cnpj",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/stats": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Stats"
+                ],
+                "summary": "Retorna estatísticas do site",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "integer",
+                                "format": "int64"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/verify-email": {
             "post": {
                 "description": "Valida o token de verificação enviado por e-mail e ativa a conta",
@@ -2533,9 +3546,43 @@
                     }
                 }
             }
+        },
+        "/visit": {
+            "post": {
+                "tags": [
+                    "Stats"
+                ],
+                "summary": "Registra visita à home page",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "absenceJustification.UpdateStatusRequest": {
+            "type": "object",
+            "required": [
+                "status"
+            ],
+            "properties": {
+                "rejection_reason": {
+                    "description": "Obrigatório quando Status=\"negado\"; ignorado/limpo nos demais status.",
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "em_analise",
+                        "aprovado",
+                        "negado",
+                        "documento_invalido"
+                    ]
+                }
+            }
+        },
         "auth.LoginUserRequest": {
             "type": "object",
             "required": [
@@ -3018,6 +4065,78 @@
                             "$ref": "#/definitions/product.ProductType"
                         }
                     ]
+                }
+            }
+        },
+        "sponsor.PublicSponsor": {
+            "type": "object",
+            "properties": {
+                "cnpj": {
+                    "type": "string"
+                },
+                "logo": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "website": {
+                    "type": "string"
+                }
+            }
+        },
+        "sponsor.Sponsor": {
+            "type": "object",
+            "properties": {
+                "clicks": {
+                    "type": "integer"
+                },
+                "cnpj": {
+                    "type": "string"
+                },
+                "logo": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "packages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sponsor.SponsorPackage"
+                    }
+                },
+                "website": {
+                    "type": "string"
+                }
+            }
+        },
+        "sponsor.SponsorPackage": {
+            "type": "object",
+            "properties": {
+                "package": {
+                    "type": "string"
+                },
+                "sponsor_cnpj": {
+                    "type": "string"
+                },
+                "year": {
+                    "type": "integer"
+                }
+            }
+        },
+        "user.PapfeApprovalRequest": {
+            "type": "object",
+            "required": [
+                "approved"
+            ],
+            "properties": {
+                "approved": {
+                    "type": "boolean"
+                },
+                "rejection_reason": {
+                    "description": "Obrigatório quando Approved=false (rejeição).",
+                    "type": "string"
                 }
             }
         },

--- a/new-site/packages/backend/docs/swagger.yaml
+++ b/new-site/packages/backend/docs/swagger.yaml
@@ -1,5 +1,21 @@
 basePath: /
 definitions:
+  absenceJustification.UpdateStatusRequest:
+    properties:
+      rejection_reason:
+        description: Obrigatório quando Status="negado"; ignorado/limpo nos demais
+          status.
+        type: string
+      status:
+        enum:
+        - em_analise
+        - aprovado
+        - negado
+        - documento_invalido
+        type: string
+    required:
+    - status
+    type: object
   auth.LoginUserRequest:
     properties:
       email:
@@ -331,6 +347,53 @@ definitions:
     - price
     - type
     type: object
+  sponsor.PublicSponsor:
+    properties:
+      cnpj:
+        type: string
+      logo:
+        type: string
+      name:
+        type: string
+      website:
+        type: string
+    type: object
+  sponsor.Sponsor:
+    properties:
+      clicks:
+        type: integer
+      cnpj:
+        type: string
+      logo:
+        type: string
+      name:
+        type: string
+      packages:
+        items:
+          $ref: '#/definitions/sponsor.SponsorPackage'
+        type: array
+      website:
+        type: string
+    type: object
+  sponsor.SponsorPackage:
+    properties:
+      package:
+        type: string
+      sponsor_cnpj:
+        type: string
+      year:
+        type: integer
+    type: object
+  user.PapfeApprovalRequest:
+    properties:
+      approved:
+        type: boolean
+      rejection_reason:
+        description: Obrigatório quando Approved=false (rejeição).
+        type: string
+    required:
+    - approved
+    type: object
   user.ResendVerificationRequest:
     properties:
       email:
@@ -450,6 +513,119 @@ info:
   title: Semcomp API
   version: "1.0"
 paths:
+  /admin/absence-justifications:
+    get:
+      description: Retorna todas as justificativas de ausência cadastradas
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Lista de justificativas de ausência
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Erro interno
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Lista justificativas de ausência
+      tags:
+      - Justificativas de Ausência
+  /admin/absence-justifications/{id}:
+    patch:
+      consumes:
+      - application/json
+      description: Aprova, rejeita, marca como documento inválido ou volta para análise
+        uma justificativa de ausência. Ao negar, o campo rejection_reason é obrigatório
+        e só persiste nesse status.
+      parameters:
+      - description: ID da justificativa
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Novo status
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/absenceJustification.UpdateStatusRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Status atualizado com sucesso!
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Dados inválidos
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Justificativa não encontrada
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Erro interno
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Atualiza o status de uma justificativa de ausência
+      tags:
+      - Justificativas de Ausência
+  /admin/absence-justifications/{id}/attachment:
+    get:
+      description: Retorna o arquivo comprobatório de uma justificativa de ausência
+        específica
+      parameters:
+      - description: ID da justificativa
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/octet-stream
+      responses:
+        "200":
+          description: Arquivo anexo
+          schema:
+            type: file
+        "400":
+          description: ID inválido
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Justificativa não encontrada
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Erro interno
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Obtém o anexo de uma justificativa de ausência
+      tags:
+      - Justificativas de Ausência
   /admin/events:
     post:
       consumes:
@@ -634,6 +810,28 @@ paths:
       summary: Login do backoffice
       tags:
       - Auth Backoffice
+  /admin/papfe-documents:
+    get:
+      description: Retorna metadados de todos os comprovantes PAPFE cadastrados
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Lista de comprovantes PAPFE
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Erro interno
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Lista comprovantes PAPFE
+      tags:
+      - Usuários (Participantes)
   /admin/permissions:
     get:
       consumes:
@@ -1387,6 +1585,137 @@ paths:
       summary: Atualiza produto
       tags:
       - Product Backoffice
+  /admin/sponsors:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Lista todos os patrocinadores (admin)
+      tags:
+      - Sponsors Backoffice
+    post:
+      consumes:
+      - multipart/form-data
+      produces:
+      - application/json
+      responses: {}
+      security:
+      - BearerAuth: []
+      summary: Cria patrocinador (admin)
+      tags:
+      - Sponsors Backoffice
+  /admin/sponsors/{cnpj}:
+    delete:
+      parameters:
+      - description: CNPJ do patrocinador
+        in: path
+        name: cnpj
+        required: true
+        type: string
+      responses: {}
+      security:
+      - BearerAuth: []
+      summary: Remove patrocinador (admin)
+      tags:
+      - Sponsors Backoffice
+    get:
+      parameters:
+      - description: CNPJ do patrocinador
+        in: path
+        name: cnpj
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/sponsor.Sponsor'
+      security:
+      - BearerAuth: []
+      summary: Busca patrocinador por CNPJ (admin)
+      tags:
+      - Sponsors Backoffice
+    put:
+      consumes:
+      - multipart/form-data
+      parameters:
+      - description: CNPJ do patrocinador
+        in: path
+        name: cnpj
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses: {}
+      security:
+      - BearerAuth: []
+      summary: Atualiza patrocinador (admin)
+      tags:
+      - Sponsors Backoffice
+  /admin/sponsors/{cnpj}/packages:
+    get:
+      parameters:
+      - description: CNPJ do patrocinador
+        in: path
+        name: cnpj
+        required: true
+        type: string
+      - description: Filtrar por ano
+        in: query
+        name: year
+        type: integer
+      responses: {}
+      security:
+      - BearerAuth: []
+      summary: Lista pacotes de patrocinador (admin)
+      tags:
+      - Sponsors Backoffice
+    post:
+      parameters:
+      - description: CNPJ do patrocinador
+        in: path
+        name: cnpj
+        required: true
+        type: string
+      responses: {}
+      security:
+      - BearerAuth: []
+      summary: Adiciona pacote de patrocinador (admin)
+      tags:
+      - Sponsors Backoffice
+  /admin/sponsors/{cnpj}/packages/{year}/{package}:
+    delete:
+      parameters:
+      - description: CNPJ do patrocinador
+        in: path
+        name: cnpj
+        required: true
+        type: string
+      - description: Ano do pacote
+        in: path
+        name: year
+        required: true
+        type: integer
+      - description: Nome do pacote
+        in: path
+        name: package
+        required: true
+        type: string
+      responses: {}
+      security:
+      - BearerAuth: []
+      summary: Remove pacote de patrocinador (admin)
+      tags:
+      - Sponsors Backoffice
   /admin/users:
     get:
       consumes:
@@ -1575,6 +1904,95 @@ paths:
       security:
       - BearerAuth: []
       summary: Atualiza usuário
+      tags:
+      - Usuários (Participantes)
+  /admin/users/{id}/papfe-document:
+    get:
+      description: Retorna o arquivo do comprovante PAPFE de um usuário específico
+      parameters:
+      - description: ID do usuário
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/octet-stream
+      responses:
+        "200":
+          description: Arquivo do comprovante PAPFE
+          schema:
+            type: file
+        "400":
+          description: ID inválido
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Usuário ou comprovante não encontrado
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Erro interno
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Obtém comprovante PAPFE de um usuário
+      tags:
+      - Usuários (Participantes)
+  /admin/users/{id}/papfe-document/approval:
+    put:
+      consumes:
+      - application/json
+      description: Altera o status de aprovação do comprovante PAPFE de um usuário.
+        Ao rejeitar, o campo rejection_reason é obrigatório e só persiste nesse status.
+      parameters:
+      - description: ID do usuário
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Status de aprovação
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/user.PapfeApprovalRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Status de aprovação atualizado com sucesso!
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Dados inválidos
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Usuário ou comprovante não encontrado
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Erro interno
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Aprova/rejeita comprovante PAPFE
       tags:
       - Usuários (Participantes)
   /admin/usersBackoffice:
@@ -1773,6 +2191,259 @@ paths:
       summary: Atualiza usuário do backoffice
       tags:
       - Usuários (Admins)
+  /api/absence-justifications:
+    post:
+      consumes:
+      - multipart/form-data
+      description: Registra a justificativa de ausência (referente à SEMCOMP como
+        um todo) do usuário autenticado, com anexo comprobatório. Cada usuário só
+        pode ter uma justificativa.
+      parameters:
+      - description: Motivo da ausência
+        in: formData
+        name: reason
+        required: true
+        type: string
+      - description: Comprovante (PDF/JPEG/PNG/WebP, máx 10MB)
+        in: formData
+        name: attachment
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Justificativa enviada com sucesso!
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Dados inválidos
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: Justificativa já enviada
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Erro interno
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Envia a justificativa de ausência do usuário autenticado
+      tags:
+      - Justificativas de Ausência
+  /api/absence-justifications/{id}:
+    patch:
+      consumes:
+      - multipart/form-data
+      description: Edita o motivo e, opcionalmente, substitui o anexo da justificativa
+        do usuário autenticado. Permitido apenas quando o status for "em_analise"
+        ou "documento_invalido"; editar reenvia a justificativa para análise.
+      parameters:
+      - description: ID da justificativa
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Motivo da ausência
+        in: formData
+        name: reason
+        required: true
+        type: string
+      - description: Novo comprovante (opcional, substitui o anterior)
+        in: formData
+        name: attachment
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Justificativa atualizada com sucesso!
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Dados inválidos
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Justificativa não pertence ao usuário
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Justificativa não encontrada
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: Justificativa já aprovada ou negada
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Erro interno
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Atualiza a justificativa de ausência do usuário autenticado
+      tags:
+      - Justificativas de Ausência
+  /api/absence-justifications/{id}/attachment:
+    get:
+      description: Retorna o arquivo comprobatório da justificativa do usuário autenticado
+      parameters:
+      - description: ID da justificativa
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/octet-stream
+      responses:
+        "200":
+          description: Arquivo anexo
+          schema:
+            type: file
+        "400":
+          description: ID inválido
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Justificativa não pertence ao usuário
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Justificativa não encontrada
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Erro interno
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Obtém o anexo da própria justificativa de ausência
+      tags:
+      - Justificativas de Ausência
+  /api/absence-justifications/mine:
+    get:
+      description: Retorna a justificativa de ausência enviada pelo usuário autenticado,
+        se houver
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Justificativa do usuário
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Nenhuma justificativa enviada
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Erro interno
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Obtém a justificativa de ausência do usuário autenticado
+      tags:
+      - Justificativas de Ausência
+  /api/papfe-document:
+    get:
+      description: Retorna os metadados do comprovante PAPFE do usuário autenticado
+        (sem os bytes do arquivo), incluindo o motivo da rejeição quando houver
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Comprovante PAPFE do usuário
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Nenhum comprovante enviado
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Erro interno
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Obtém o próprio comprovante PAPFE
+      tags:
+      - Usuários (Participantes)
+    put:
+      consumes:
+      - multipart/form-data
+      description: Atualiza o comprovante PAPFE do usuário autenticado. Aceita multipart/form-data.
+      parameters:
+      - description: Comprovante PAPFE (PDF/JPEG/PNG/WebP, máx 10MB)
+        in: formData
+        name: papfe_document
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Comprovante PAPFE atualizado com sucesso!
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Dados inválidos
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Erro interno
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Atualiza comprovante PAPFE
+      tags:
+      - Usuários (Participantes)
   /api/profile:
     get:
       description: Retorna os dados do usuário autenticado via token JWT
@@ -2073,6 +2744,55 @@ paths:
       summary: Reenvia e-mail de confirmação
       tags:
       - Usuários (Participantes)
+  /sponsors:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/sponsor.PublicSponsor'
+            type: array
+      summary: Lista patrocinadores públicos
+      tags:
+      - Sponsors
+  /sponsors/{cnpj}/click:
+    post:
+      parameters:
+      - description: CNPJ do patrocinador (14 dígitos)
+        in: path
+        name: cnpj
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Registra clique em patrocinador
+      tags:
+      - Sponsors
+  /stats:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              format: int64
+              type: integer
+            type: object
+      summary: Retorna estatísticas do site
+      tags:
+      - Stats
   /verify-email:
     post:
       consumes:
@@ -2109,6 +2829,14 @@ paths:
       summary: Confirma e-mail de um usuário
       tags:
       - Usuários (Participantes)
+  /visit:
+    post:
+      responses:
+        "204":
+          description: No Content
+      summary: Registra visita à home page
+      tags:
+      - Stats
 securityDefinitions:
   BearerAuth:
     description: 'Insira o token no formato: Bearer {seu_token}'

--- a/new-site/packages/backend/internal/absenceJustification/handler.go
+++ b/new-site/packages/backend/internal/absenceJustification/handler.go
@@ -263,7 +263,7 @@ func (h *AbsenceJustificationHandler) GetAttachment(c *gin.Context) {
 
 // UpdateStatus altera o status de uma justificativa de ausência (admin).
 // @Summary Atualiza o status de uma justificativa de ausência
-// @Description Aprova, rejeita, marca como documento inválido ou volta para análise uma justificativa de ausência
+// @Description Aprova, rejeita, marca como documento inválido ou volta para análise uma justificativa de ausência. Ao negar, o campo rejection_reason é obrigatório e só persiste nesse status.
 // @Tags Justificativas de Ausência
 // @Accept json
 // @Produce json
@@ -288,7 +288,7 @@ func (h *AbsenceJustificationHandler) UpdateStatus(c *gin.Context) {
 		return
 	}
 
-	if err := h.service.UpdateStatus(uint(id), request.Status); err != nil {
+	if err := h.service.UpdateStatus(uint(id), request.Status, request.RejectionReason); err != nil {
 		apierrors.HandleAPIError(c, err)
 		return
 	}

--- a/new-site/packages/backend/internal/absenceJustification/model.go
+++ b/new-site/packages/backend/internal/absenceJustification/model.go
@@ -28,6 +28,9 @@ type AbsenceJustification struct {
 	AttachmentFilePath    string    `gorm:"size:500;not null"`
 	SubmittedAt           time.Time `gorm:"not null"`
 	Status                string    `gorm:"size:20;not null;default:em_analise"`
+	// RejectionReason só existe quando o status é "negado"; em qualquer outro status
+	// permanece NULL e é omitido nas respostas JSON.
+	RejectionReason *string `gorm:"type:text"`
 }
 
 type CreateAbsenceJustificationRequest struct {
@@ -53,6 +56,9 @@ type UpdateAbsenceJustificationRequest struct {
 
 type UpdateStatusRequest struct {
 	Status string `json:"status" binding:"required,oneof=em_analise aprovado negado documento_invalido"`
+
+	// Obrigatório quando Status="negado"; ignorado/limpo nos demais status.
+	RejectionReason string `json:"rejection_reason"`
 }
 
 // AbsenceJustificationInfo é a projeção retornada tanto para o backoffice quanto para
@@ -69,4 +75,7 @@ type AbsenceJustificationInfo struct {
 	AttachmentContentType string    `json:"attachment_content_type"`
 	SubmittedAt           time.Time `json:"submitted_at"`
 	Status                string    `json:"status"`
+
+	// Só presente quando Status="negado"; omitido caso contrário.
+	RejectionReason *string `json:"rejection_reason,omitempty"`
 }

--- a/new-site/packages/backend/internal/absenceJustification/repository.go
+++ b/new-site/packages/backend/internal/absenceJustification/repository.go
@@ -16,7 +16,7 @@ type AbsenceJustificationRepository interface {
 	FindByUserEmail(email string) (*AbsenceJustification, error)
 	FindInfoByID(id uint) (*AbsenceJustificationInfo, error)
 	FindInfoByUserEmail(email string) (*AbsenceJustificationInfo, error)
-	UpdateStatus(id uint, status string) error
+	UpdateStatus(id uint, status string, rejectionReason *string) error
 }
 
 type absenceJustificationRepository struct {
@@ -31,6 +31,8 @@ func (r *absenceJustificationRepository) Create(justification *AbsenceJustificat
 	return r.db.Create(justification).Error
 }
 
+// Update permite que o participante edite o motivo/anexo enquanto em análise ou com
+// documento inválido. Editar reenvia para análise, então o motivo de rejeição é limpo.
 func (r *absenceJustificationRepository) Update(justification *AbsenceJustification) error {
 	result := r.db.Model(&AbsenceJustification{}).Where("id = ?", justification.ID).Updates(map[string]interface{}{
 		"reason":                  justification.Reason,
@@ -38,6 +40,7 @@ func (r *absenceJustificationRepository) Update(justification *AbsenceJustificat
 		"attachment_filename":     justification.AttachmentFilename,
 		"attachment_content_type": justification.AttachmentContentType,
 		"attachment_file_path":    justification.AttachmentFilePath,
+		"rejection_reason":        justification.RejectionReason,
 	})
 	if result.Error != nil {
 		return apierrors.InternalServerError("Erro ao atualizar justificativa de ausência", result.Error)
@@ -52,7 +55,7 @@ func (r *absenceJustificationRepository) Update(justification *AbsenceJustificat
 // FindAll, FindInfoByID e FindInfoByUserEmail.
 func (r *absenceJustificationRepository) infoQuery() *gorm.DB {
 	return r.db.Table("absence_justifications aj").
-		Select("aj.id, u.user_number, u.name AS user_name, aj.user_email, aj.event_name, aj.event_init_date, aj.reason, aj.attachment_filename, aj.attachment_content_type, aj.submitted_at, aj.status").
+		Select("aj.id, u.user_number, u.name AS user_name, aj.user_email, aj.event_name, aj.event_init_date, aj.reason, aj.attachment_filename, aj.attachment_content_type, aj.submitted_at, aj.status, aj.rejection_reason").
 		Joins("JOIN users u ON u.email = aj.user_email")
 }
 
@@ -115,8 +118,13 @@ func (r *absenceJustificationRepository) FindInfoByUserEmail(email string) (*Abs
 	return &info, nil
 }
 
-func (r *absenceJustificationRepository) UpdateStatus(id uint, status string) error {
-	result := r.db.Model(&AbsenceJustification{}).Where("id = ?", id).Update("status", status)
+// UpdateStatus atualiza o status de uma justificativa. rejectionReason só deve ser
+// não-nulo quando status="negado"; nos demais status deve vir nil para limpar o motivo.
+func (r *absenceJustificationRepository) UpdateStatus(id uint, status string, rejectionReason *string) error {
+	result := r.db.Model(&AbsenceJustification{}).Where("id = ?", id).Updates(map[string]interface{}{
+		"status":           status,
+		"rejection_reason": rejectionReason,
+	})
 	if result.Error != nil {
 		return apierrors.InternalServerError("Erro ao atualizar status da justificativa de ausência", result.Error)
 	}

--- a/new-site/packages/backend/internal/absenceJustification/service.go
+++ b/new-site/packages/backend/internal/absenceJustification/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"backend/internal/apierrors"
@@ -17,7 +18,7 @@ type AbsenceJustificationService interface {
 	GetOwnAttachment(userEmail string, id uint) (*AbsenceJustification, error)
 	GetAllAbsenceJustifications() ([]AbsenceJustificationInfo, error)
 	GetAttachment(id uint) (*AbsenceJustification, error)
-	UpdateStatus(id uint, status string) error
+	UpdateStatus(id uint, status string, rejectionReason string) error
 }
 
 type absenceJustificationService struct {
@@ -90,6 +91,8 @@ func (s *absenceJustificationService) UpdateJustification(userEmail string, id u
 
 	justification.Reason = request.Reason
 	justification.Status = StatusEmAnalise
+	// Reenviar para análise limpa qualquer motivo de rejeição anterior.
+	justification.RejectionReason = nil
 
 	oldFilePath := ""
 	if len(request.AttachmentData) > 0 {
@@ -136,8 +139,17 @@ func (s *absenceJustificationService) GetAttachment(id uint) (*AbsenceJustificat
 	return s.repo.FindByID(id)
 }
 
-func (s *absenceJustificationService) UpdateStatus(id uint, status string) error {
-	return s.repo.UpdateStatus(id, status)
+// UpdateStatus altera o status de uma justificativa (admin). O motivo da negativa é
+// obrigatório quando status="negado" e só persiste nesse status; em qualquer outro
+// status o motivo é sempre limpo.
+func (s *absenceJustificationService) UpdateStatus(id uint, status string, rejectionReason string) error {
+	if status == StatusNegado {
+		if strings.TrimSpace(rejectionReason) == "" {
+			return apierrors.ValidationError("Informe o motivo da negativa da justificativa", nil)
+		}
+		return s.repo.UpdateStatus(id, status, &rejectionReason)
+	}
+	return s.repo.UpdateStatus(id, status, nil)
 }
 
 const attachmentUploadDir = "uploads/absence-justifications"

--- a/new-site/packages/backend/internal/user/handler.go
+++ b/new-site/packages/backend/internal/user/handler.go
@@ -239,9 +239,31 @@ func (h *UserHandler) GetPapfeDocument(c *gin.Context) {
 	c.File(doc.FilePath)
 }
 
+// GetMyPapfeDocument serve os metadados do comprovante PAPFE do usuário autenticado.
+// @Summary Obtém o próprio comprovante PAPFE
+// @Description Retorna os metadados do comprovante PAPFE do usuário autenticado (sem os bytes do arquivo), incluindo o motivo da rejeição quando houver
+// @Tags Usuários (Participantes)
+// @Produce json
+// @Success 200 {object} map[string]interface{} "Comprovante PAPFE do usuário"
+// @Failure 404 {object} map[string]string "Nenhum comprovante enviado"
+// @Failure 500 {object} map[string]string "Erro interno"
+// @Security BearerAuth
+// @Router /api/papfe-document [get]
+func (h *UserHandler) GetMyPapfeDocument(c *gin.Context) {
+	email := c.MustGet("email").(string)
+
+	doc, err := h.userService.GetMyPapfeDocument(email)
+	if err != nil {
+		apierrors.HandleAPIError(c, err)
+		return
+	}
+	c.Set("responseMessage", "Comprovante PAPFE obtido com sucesso!")
+	c.JSON(http.StatusOK, gin.H{"papfe_document": doc})
+}
+
 // ApprovePapfeDocument altera o status de aprovação do comprovante PAPFE de um usuário (admin).
 // @Summary Aprova/rejeita comprovante PAPFE
-// @Description Altera o status de aprovação do comprovante PAPFE de um usuário
+// @Description Altera o status de aprovação do comprovante PAPFE de um usuário. Ao rejeitar, o campo rejection_reason é obrigatório e só persiste nesse status.
 // @Tags Usuários (Participantes)
 // @Accept json
 // @Produce json
@@ -272,7 +294,7 @@ func (h *UserHandler) ApprovePapfeDocument(c *gin.Context) {
 		return
 	}
 
-	if err := h.userService.ApprovePapfeDocument(user.Email, *request.Approved); err != nil {
+	if err := h.userService.ApprovePapfeDocument(user.Email, *request.Approved, request.RejectionReason); err != nil {
 		apierrors.HandleAPIError(c, err)
 		return
 	}

--- a/new-site/packages/backend/internal/user/handler_test.go
+++ b/new-site/packages/backend/internal/user/handler_test.go
@@ -47,7 +47,10 @@ func (m *MockUserService) GetPapfeDocument(email string) (*PapfeDocument, error)
 func (m *MockUserService) UpdatePapfeDocument(email string, filename string, contentType string, data []byte) error {
 	panic("not implemented in mock")
 }
-func (m *MockUserService) ApprovePapfeDocument(email string, approved bool) error {
+func (m *MockUserService) GetMyPapfeDocument(email string) (*PapfeDocumentInfo, error) {
+	panic("not implemented in mock")
+}
+func (m *MockUserService) ApprovePapfeDocument(email string, approved bool, rejectionReason string) error {
 	panic("not implemented in mock")
 }
 func (m *MockUserService) RequestPasswordReset(email string) error {

--- a/new-site/packages/backend/internal/user/model.go
+++ b/new-site/packages/backend/internal/user/model.go
@@ -17,6 +17,9 @@ type PapfeDocument struct {
 	FilePath    string    `gorm:"size:500;not null"`
 	UploadedAt  time.Time
 	IsApproved  *bool     `gorm:"default:null"` // nil=pendente, true=aprovado, false=rejeitado
+	// RejectionReason só existe quando o comprovante foi rejeitado (IsApproved=false);
+	// em qualquer outro status permanece NULL e é omitido nas respostas JSON.
+	RejectionReason *string `gorm:"type:text" json:"rejection_reason,omitempty"`
 }
 
 type User struct {
@@ -79,7 +82,7 @@ type UpdateUserRequest struct {
 	City         string   `json:"city" binding:"required"`
 	Education    string   `json:"education" binding:"required"`
 	HasPapfe     bool     `json:"hasPapfe"`
-	Disabilities string   `json:"disabilities" binding:"required"`
+	Disabilities []string `json:"disabilities"`
 	Profession   *string  `json:"profession,omitempty"`
 	Linkedin     *string  `json:"linkedin,omitempty"`
 	Telegram     *string  `json:"telegram,omitempty"`
@@ -156,6 +159,9 @@ type ResetPasswordRequest struct {
 
 type PapfeApprovalRequest struct {
 	Approved *bool `json:"approved" binding:"required"`
+
+	// Obrigatório quando Approved=false (rejeição).
+	RejectionReason string `json:"rejection_reason"`
 }
 
 type PapfeDocumentInfo struct {
@@ -167,4 +173,7 @@ type PapfeDocumentInfo struct {
 	ContentType string    `json:"content_type"`
 	UploadedAt  time.Time `json:"uploaded_at"`
 	IsApproved  *bool     `json:"is_approved"` // nil=pendente, true=aprovado, false=rejeitado
+
+	// Só presente quando IsApproved=false (rejeitado); omitido caso contrário.
+	RejectionReason *string `json:"rejection_reason,omitempty"`
 }

--- a/new-site/packages/backend/internal/user/repository.go
+++ b/new-site/packages/backend/internal/user/repository.go
@@ -188,8 +188,9 @@ func (r *userRepository) Delete(id uint) error {
 type PapfeDocumentRepository interface {
 	FindByEmail(email string) (*PapfeDocument, error)
 	FindAll() ([]PapfeDocumentInfo, error)
+	FindInfoByEmail(email string) (*PapfeDocumentInfo, error)
 	Upsert(doc *PapfeDocument) error
-	UpdateApproval(email string, approved bool) error
+	UpdateApproval(email string, approved bool, rejectionReason *string) error
 	DeleteByEmail(email string) error
 }
 
@@ -201,18 +202,38 @@ func NewPapfeDocumentRepository(db *gorm.DB) PapfeDocumentRepository {
 	return &papfeDocumentRepository{db: db}
 }
 
+// papfeInfoQuery monta a projeção denormalizada (join com users) compartilhada por
+// FindAll e FindInfoByEmail.
+func (r *papfeDocumentRepository) papfeInfoQuery() *gorm.DB {
+	return r.db.Table("papfe_documents pd").
+		Select("pd.id, u.user_number, u.name AS user_name, pd.user_email, pd.filename, pd.content_type, pd.uploaded_at, pd.is_approved, pd.rejection_reason").
+		Joins("JOIN users u ON u.email = pd.user_email")
+}
+
 // FindAll retorna metadados de todos os comprovantes PAPFE, com nome e número do usuário.
 func (r *papfeDocumentRepository) FindAll() ([]PapfeDocumentInfo, error) {
 	var result []PapfeDocumentInfo
-	err := r.db.Table("papfe_documents pd").
-		Select("u.user_number, u.name AS user_name, pd.user_email, pd.filename, pd.content_type, pd.uploaded_at, pd.is_approved").
-		Joins("JOIN users u ON u.email = pd.user_email").
+	err := r.papfeInfoQuery().
 		Order("pd.uploaded_at DESC").
 		Scan(&result).Error
 	if err != nil {
 		return nil, apierrors.InternalServerError("Erro ao listar comprovantes PAPFE", err)
 	}
 	return result, nil
+}
+
+// FindInfoByEmail retorna a projeção do comprovante PAPFE de um usuário pelo e-mail.
+// Usa Scan (não First), que não retorna gorm.ErrRecordNotFound quando não há linhas —
+// por isso checamos ID == 0.
+func (r *papfeDocumentRepository) FindInfoByEmail(email string) (*PapfeDocumentInfo, error) {
+	var info PapfeDocumentInfo
+	if err := r.papfeInfoQuery().Where("pd.user_email = ?", email).Scan(&info).Error; err != nil {
+		return nil, apierrors.InternalServerError("Erro ao buscar comprovante PAPFE", err)
+	}
+	if info.ID == 0 {
+		return nil, apierrors.NotFoundError("Comprovante PAPFE não encontrado", nil)
+	}
+	return &info, nil
 }
 
 // FindByEmail busca o comprovante PAPFE de um usuário pelo e-mail.
@@ -233,16 +254,21 @@ func (r *papfeDocumentRepository) Upsert(doc *PapfeDocument) error {
 	return r.db.Omit("User").
 		Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "user_email"}},
-			DoUpdates: clause.AssignmentColumns([]string{"filename", "content_type", "file_path", "uploaded_at", "is_approved"}),
+			DoUpdates: clause.AssignmentColumns([]string{"filename", "content_type", "file_path", "uploaded_at", "is_approved", "rejection_reason"}),
 		}).
 		Create(doc).Error
 }
 
 // UpdateApproval atualiza o status de aprovação do comprovante PAPFE de um usuário.
-func (r *papfeDocumentRepository) UpdateApproval(email string, approved bool) error {
+// rejectionReason só deve ser não-nulo quando approved=false (rejeição); em qualquer
+// outro caso deve vir nil para limpar o motivo.
+func (r *papfeDocumentRepository) UpdateApproval(email string, approved bool, rejectionReason *string) error {
 	result := r.db.Model(&PapfeDocument{}).
 		Where("user_email = ?", email).
-		Update("is_approved", approved)
+		Updates(map[string]interface{}{
+			"is_approved":      approved,
+			"rejection_reason": rejectionReason,
+		})
 	if result.Error != nil {
 		return apierrors.InternalServerError("Erro ao atualizar aprovação do comprovante PAPFE", result.Error)
 	}

--- a/new-site/packages/backend/internal/user/service.go
+++ b/new-site/packages/backend/internal/user/service.go
@@ -34,8 +34,9 @@ type UserService interface {
 	DeleteUser(id uint) error
 	GetAllPapfeDocuments() ([]PapfeDocumentInfo, error)
 	GetPapfeDocument(email string) (*PapfeDocument, error)
+	GetMyPapfeDocument(email string) (*PapfeDocumentInfo, error)
 	UpdatePapfeDocument(email string, filename string, contentType string, data []byte) error
-	ApprovePapfeDocument(email string, approved bool) error
+	ApprovePapfeDocument(email string, approved bool, rejectionReason string) error
 	VerifyEmail(rawToken string) error
 	ResendVerification(email string) error
 	RequestPasswordReset(email string) error
@@ -238,9 +239,13 @@ func (s *userService) regenerateAndSendVerification(u *User) {
 		return
 	}
 
-	if err := s.mailProvider.SendVerificationEmail(u.Email, u.Name, raw); err != nil {
-		log.Printf("[email] falha ao enviar verificação para %s: %v", u.Email, err)
-	}
+	// Envio assíncrono: o SMTP não deve bloquear a resposta do request — o token já
+	// foi persistido acima e falhas de envio são best-effort (o usuário pode reenviar).
+	go func() {
+		if err := s.mailProvider.SendVerificationEmail(u.Email, u.Name, raw); err != nil {
+			log.Printf("[email] falha ao enviar verificação para %s: %v", u.Email, err)
+		}
+	}()
 }
 
 func verificationTokenTTL() time.Duration {
@@ -401,7 +406,7 @@ func (s *userService) UpdateUser(id uint, request UpdateUserRequest) error {
 	user.City = request.City
 	user.Education = request.Education
 	user.HasPapfe = request.HasPapfe
-	user.Disabilities = request.Disabilities
+	user.Disabilities = strings.Join(request.Disabilities, ", ")
 	user.Profession = request.Profession
 	user.Linkedin = request.Linkedin
 	user.Telegram = request.Telegram
@@ -466,6 +471,11 @@ func (s *userService) GetPapfeDocument(email string) (*PapfeDocument, error) {
 	return doc, nil
 }
 
+// GetMyPapfeDocument retorna a projeção do comprovante PAPFE do usuário autenticado.
+func (s *userService) GetMyPapfeDocument(email string) (*PapfeDocumentInfo, error) {
+	return s.papfeRepo.FindInfoByEmail(email)
+}
+
 // UpdatePapfeDocument atualiza (ou insere) o comprovante PAPFE do usuário autenticado.
 // O arquivo anterior é removido do disco antes de salvar o novo.
 func (s *userService) UpdatePapfeDocument(email string, filename string, contentType string, data []byte) error {
@@ -483,6 +493,7 @@ func (s *userService) UpdatePapfeDocument(email string, filename string, content
 		FilePath:    filePath,
 		UploadedAt:  time.Now(),
 		IsApproved:  nil, // reset para pendente ao enviar novo comprovante
+		// RejectionReason permanece nil: novo envio limpa qualquer motivo anterior.
 	}
 	if err := s.papfeRepo.Upsert(doc); err != nil {
 		_ = os.Remove(filePath)
@@ -496,8 +507,16 @@ func (s *userService) UpdatePapfeDocument(email string, filename string, content
 }
 
 // ApprovePapfeDocument atualiza o status de aprovação do comprovante PAPFE de um usuário.
-func (s *userService) ApprovePapfeDocument(email string, approved bool) error {
-	return s.papfeRepo.UpdateApproval(email, approved)
+// O motivo da rejeição é obrigatório quando approved=false e só persiste nesse caso;
+// ao aprovar (ou voltar para análise) o motivo é sempre limpo.
+func (s *userService) ApprovePapfeDocument(email string, approved bool, rejectionReason string) error {
+	if approved {
+		return s.papfeRepo.UpdateApproval(email, true, nil)
+	}
+	if strings.TrimSpace(rejectionReason) == "" {
+		return apierrors.ValidationError("Informe o motivo da rejeição do comprovante", nil)
+	}
+	return s.papfeRepo.UpdateApproval(email, false, &rejectionReason)
 }
 
 func (s *userService) RequestPasswordReset(email string) error {

--- a/new-site/packages/backend/internal/user/service_test.go
+++ b/new-site/packages/backend/internal/user/service_test.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -57,12 +58,21 @@ func (m *MockTokenProvider) Hash(raw string) string            { return m.HashFu
 // MockMailProvider implementa providers.MailProvider manualmente
 type MockMailProvider struct {
 	SendVerificationEmailFunc func(to string, name string, rawToken string) error
-	Calls                     int
+	Calls                     int32
 }
 
 func (m *MockMailProvider) SendVerificationEmail(to string, name string, rawToken string) error {
-	m.Calls++
+	atomic.AddInt32(&m.Calls, 1)
 	return m.SendVerificationEmailFunc(to, name, rawToken)
+}
+
+// waitForCalls aguarda (com timeout) até o número esperado de envios de e-mail,
+// já que o envio agora acontece em goroutine assíncrona.
+func (m *MockMailProvider) waitForCalls(n int, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for atomic.LoadInt32(&m.Calls) < int32(n) && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
 }
 
 // MockEmailValidationProvider implementa providers.EmailValidationProvider manualmente
@@ -112,8 +122,9 @@ func TestCreateUser_NewUser_Success(t *testing.T) {
 	if created.VerificationTokenHash == "" {
 		t.Fatalf("token de verificação deveria ter sido persistido")
 	}
-	if mail.Calls != 1 {
-		t.Fatalf("esperado 1 envio de e-mail, recebido %d", mail.Calls)
+	mail.waitForCalls(1, time.Second)
+	if atomic.LoadInt32(&mail.Calls) != 1 {
+		t.Fatalf("esperado 1 envio de e-mail, recebido %d", atomic.LoadInt32(&mail.Calls))
 	}
 	if safeUser.Email != "ana@example.com" {
 		t.Fatalf("safeUser inesperado: %v", safeUser)
@@ -142,7 +153,7 @@ func TestCreateUser_ExistingVerified_Conflict(t *testing.T) {
 	if apiErr == nil || apiErr.Code != "conflict" {
 		t.Fatalf("esperado erro de conflito, recebido: %v", err)
 	}
-	if mail.Calls != 0 {
+	if atomic.LoadInt32(&mail.Calls) != 0 {
 		t.Fatalf("não deveria reenviar e-mail para conta já verificada")
 	}
 }
@@ -172,7 +183,8 @@ func TestCreateUser_ExistingUnverified_ResendsWithoutOverwrite(t *testing.T) {
 	if updated == nil || updated.Name != "Nome Original" || updated.PasswordHash != "hash-original" {
 		t.Fatalf("nome/senha do usuário existente não deveriam ser sobrescritos: %+v", updated)
 	}
-	if mail.Calls != 1 {
+	mail.waitForCalls(1, time.Second)
+	if atomic.LoadInt32(&mail.Calls) != 1 {
 		t.Fatalf("esperado reenvio do e-mail de confirmação")
 	}
 	if safeUser.Name != "Nome Original" {
@@ -273,7 +285,7 @@ func TestResendVerification_AlwaysGeneric(t *testing.T) {
 		if err := service.ResendVerification("naoexiste@example.com"); err != nil {
 			t.Fatalf("esperado nil, recebido: %v", err)
 		}
-		if mail.Calls != 0 {
+		if atomic.LoadInt32(&mail.Calls) != 0 {
 			t.Fatalf("não deveria enviar e-mail para conta inexistente")
 		}
 	})
@@ -288,7 +300,7 @@ func TestResendVerification_AlwaysGeneric(t *testing.T) {
 		if err := service.ResendVerification("ana@example.com"); err != nil {
 			t.Fatalf("esperado nil, recebido: %v", err)
 		}
-		if mail.Calls != 0 {
+		if atomic.LoadInt32(&mail.Calls) != 0 {
 			t.Fatalf("não deveria reenviar e-mail para conta já verificada")
 		}
 	})
@@ -306,7 +318,7 @@ func TestResendVerification_AlwaysGeneric(t *testing.T) {
 		if err := service.ResendVerification("ana@example.com"); err != nil {
 			t.Fatalf("esperado nil, recebido: %v", err)
 		}
-		if mail.Calls != 0 {
+		if atomic.LoadInt32(&mail.Calls) != 0 {
 			t.Fatalf("não deveria reenviar e-mail durante o cooldown")
 		}
 	})
@@ -322,7 +334,8 @@ func TestResendVerification_AlwaysGeneric(t *testing.T) {
 		if err := service.ResendVerification("ana@example.com"); err != nil {
 			t.Fatalf("esperado nil, recebido: %v", err)
 		}
-		if mail.Calls != 1 {
+		mail.waitForCalls(1, time.Second)
+		if atomic.LoadInt32(&mail.Calls) != 1 {
 			t.Fatalf("esperado reenvio do e-mail de confirmação")
 		}
 	})

--- a/new-site/packages/front-backoffice/src/api/absenceJustifications.ts
+++ b/new-site/packages/front-backoffice/src/api/absenceJustifications.ts
@@ -25,11 +25,12 @@ export const absenceJustificationsAPI = {
 
   updateStatus: async (
     id: number,
-    status: AbsenceJustificationStatus
+    status: AbsenceJustificationStatus,
+    rejectionReason?: string
   ): Promise<{ message: string }> => {
     const response = await client.patch<{ message: string }>(
       `/admin/absence-justifications/${id}`,
-      { status }
+      { status, rejection_reason: rejectionReason ?? "" }
     );
     return response.data;
   },

--- a/new-site/packages/front-backoffice/src/api/client.ts
+++ b/new-site/packages/front-backoffice/src/api/client.ts
@@ -4,7 +4,7 @@ import { BASEURL } from "@/constants/ApiURL";
 
 const client: AxiosInstance = axios.create({
   baseURL: BASEURL,
-  timeout: 10000,
+  timeout: 30000,
   withCredentials: true,
   headers: {
     "Content-Type": "application/json",

--- a/new-site/packages/front-backoffice/src/api/users.ts
+++ b/new-site/packages/front-backoffice/src/api/users.ts
@@ -26,6 +26,7 @@ export type PapfeDocumentInfo = {
   content_type: string;
   uploaded_at: string;
   is_approved: boolean | null; // null=pendente, true=aprovado, false=rejeitado
+  rejection_reason?: string | null; // só existe quando rejeitado
 };
 
 const mapBackendUser = (user: SafeSemcompUser): SemcompUserType => {
@@ -239,10 +240,14 @@ export const papfeAPI = {
     return response.data as Blob;
   },
 
-  approve: async (userId: number, approved: boolean): Promise<{ message: string }> => {
+  approve: async (
+    userId: number,
+    approved: boolean,
+    rejectionReason?: string
+  ): Promise<{ message: string }> => {
     const response = await client.put<{ message: string }>(
       `/admin/users/${userId}/papfe-document/approval`,
-      { approved }
+      { approved, rejection_reason: rejectionReason ?? "" }
     );
     return response.data;
   },

--- a/new-site/packages/front-backoffice/src/components/RejectionReasonInput.tsx
+++ b/new-site/packages/front-backoffice/src/components/RejectionReasonInput.tsx
@@ -1,0 +1,43 @@
+import { useId } from "react";
+
+type RejectionReasonInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  required?: boolean;
+};
+
+/**
+ * Campo reutilizável de texto para o motivo da rejeição/negativa,
+ * usado no fluxo de aprovar/rejeitar comprovantes PAPFE e justificativas.
+ */
+export function RejectionReasonInput({
+  value,
+  onChange,
+  placeholder = "Explique o motivo da rejeição para o participante...",
+  required = true,
+}: RejectionReasonInputProps) {
+  const id = useId();
+  return (
+    <div className="space-y-1.5">
+      <label
+        htmlFor={id}
+        className="text-sm font-medium text-foreground"
+      >
+        Motivo da rejeição {required && <span className="text-red-400">*</span>}
+      </label>
+      <textarea
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        rows={4}
+        required={required}
+        className="bg-muted/40 border-muted/30 text-foreground focus-visible:ring-primary rounded-lg w-full min-h-24 max-h-48 resize-y px-3 py-2 text-sm"
+      />
+      <p className="text-xs text-muted-foreground">
+        O participante verá este texto no site.
+      </p>
+    </div>
+  );
+}

--- a/new-site/packages/front-backoffice/src/hooks/useAbsenceJustifications.ts
+++ b/new-site/packages/front-backoffice/src/hooks/useAbsenceJustifications.ts
@@ -34,10 +34,22 @@ export function useAbsenceJustifications() {
   }, [fetchJustifications]);
 
   const updateStatus = useCallback(
-    async (id: number, status: AbsenceJustificationStatus) => {
-      await absenceJustificationsAPI.updateStatus(id, status);
+    async (
+      id: number,
+      status: AbsenceJustificationStatus,
+      rejectionReason?: string
+    ) => {
+      await absenceJustificationsAPI.updateStatus(id, status, rejectionReason);
       setJustifications((prev) =>
-        prev.map((j) => (j.id === id ? { ...j, status } : j))
+        prev.map((j) =>
+          j.id === id
+            ? {
+                ...j,
+                status,
+                rejection_reason: rejectionReason ?? null,
+              }
+            : j
+        )
       );
     },
     []

--- a/new-site/packages/front-backoffice/src/pages/AbsenceJustifications/index.tsx
+++ b/new-site/packages/front-backoffice/src/pages/AbsenceJustifications/index.tsx
@@ -14,6 +14,7 @@ import { useNotification } from "@/contexts/NotificationContext";
 import { useHasPermission } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { RejectionReasonInput } from "@/components/RejectionReasonInput";
 import { Eye, Download } from "lucide-react";
 import {
   Dialog,
@@ -104,12 +105,14 @@ export default function AbsenceJustifications() {
   const [modal, setModal] = useState<ModalState>({ open: false });
   const [pendingDecision, setPendingDecision] =
     useState<AbsenceJustificationStatus | null>(null);
+  const [rejectionReason, setRejectionReason] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
   const rows = useMemo(() => justifications.map(toRow), [justifications]);
 
   const openModal = async (justification: AbsenceJustificationType) => {
     setPendingDecision(null);
+    setRejectionReason("");
     setModal({
       open: true,
       justification,
@@ -137,6 +140,7 @@ export default function AbsenceJustifications() {
       URL.revokeObjectURL(modal.attachmentUrl);
     setModal({ open: false });
     setPendingDecision(null);
+    setRejectionReason("");
   };
 
   const handleAction = (item: CrudItemType) => {
@@ -146,12 +150,28 @@ export default function AbsenceJustifications() {
 
   const confirmDecision = async () => {
     if (!modal.open || !pendingDecision) return;
+    if (
+      pendingDecision === "negado" &&
+      !rejectionReason.trim()
+    ) {
+      showNotification("Informe o motivo da negativa.", "warning");
+      return;
+    }
     setSubmitting(true);
     try {
-      await updateStatus(modal.justification.id, pendingDecision);
+      await updateStatus(
+        modal.justification.id,
+        pendingDecision,
+        pendingDecision === "negado" ? rejectionReason.trim() : undefined
+      );
       setModal({
         ...modal,
-        justification: { ...modal.justification, status: pendingDecision },
+        justification: {
+          ...modal.justification,
+          status: pendingDecision,
+          rejection_reason:
+            pendingDecision === "negado" ? rejectionReason.trim() : null,
+        },
       });
       showNotification(
         pendingDecision === "aprovado"
@@ -162,6 +182,7 @@ export default function AbsenceJustifications() {
         pendingDecision === "aprovado" ? "success" : "warning"
       );
       setPendingDecision(null);
+      setRejectionReason("");
     } catch (err: unknown) {
       const msg =
         (err as { response?: { data?: { message?: string } } })?.response
@@ -238,6 +259,18 @@ export default function AbsenceJustifications() {
                 <StatusBadge status={modal.justification.status} />
               </div>
 
+              {modal.justification.status === "negado" &&
+                modal.justification.rejection_reason && (
+                  <div className="space-y-1.5">
+                    <p className="text-sm text-muted-foreground">
+                      Motivo da negativa
+                    </p>
+                    <p className="text-sm text-foreground whitespace-pre-line rounded-lg border border-border bg-muted/30 p-3">
+                      {modal.justification.rejection_reason}
+                    </p>
+                  </div>
+                )}
+
               <div className="space-y-1.5">
                 <p className="text-sm text-muted-foreground">Justificativa</p>
                 <p className="text-sm text-foreground whitespace-pre-line rounded-lg border border-border bg-muted/30 p-3">
@@ -289,39 +322,50 @@ export default function AbsenceJustifications() {
               {canWrite && (
                 <DialogFooter className="flex-col items-stretch gap-3 sm:flex-col sm:items-stretch">
                   {pendingDecision ? (
-                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                      <p className="text-sm text-foreground">
-                        Confirma{" "}
-                        {pendingDecision === "aprovado"
-                          ? "aprovar"
-                          : pendingDecision === "negado"
-                            ? "negar"
-                            : "marcar como documento inválido"}{" "}
-                        esta justificativa?
-                      </p>
-                      <div className="flex gap-2 justify-end">
-                        <Button
-                          variant="ghost"
-                          onClick={() => setPendingDecision(null)}
-                          disabled={submitting}
-                          className="text-muted-foreground"
-                        >
-                          Cancelar
-                        </Button>
-                        <Button
-                          onClick={confirmDecision}
-                          disabled={submitting}
-                          className={
-                            pendingDecision === "aprovado"
-                              ? "bg-emerald-600 hover:bg-emerald-700 text-white"
-                              : pendingDecision === "negado"
-                                ? "bg-red-600 hover:bg-red-700 text-white"
-                                : "bg-orange-600 hover:bg-orange-700 text-white"
-                          }
-                        >
-                          Confirmar
-                        </Button>
+                    <div className="flex flex-col gap-3">
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                        <p className="text-sm text-foreground">
+                          Confirma{" "}
+                          {pendingDecision === "aprovado"
+                            ? "aprovar"
+                            : pendingDecision === "negado"
+                              ? "negar"
+                              : "marcar como documento inválido"}{" "}
+                          esta justificativa?
+                        </p>
+                        <div className="flex gap-2 justify-end">
+                          <Button
+                            variant="ghost"
+                            onClick={() => {
+                              setPendingDecision(null);
+                              setRejectionReason("");
+                            }}
+                            disabled={submitting}
+                            className="text-muted-foreground"
+                          >
+                            Cancelar
+                          </Button>
+                          <Button
+                            onClick={confirmDecision}
+                            disabled={submitting}
+                            className={
+                              pendingDecision === "aprovado"
+                                ? "bg-emerald-600 hover:bg-emerald-700 text-white"
+                                : pendingDecision === "negado"
+                                  ? "bg-red-600 hover:bg-red-700 text-white"
+                                  : "bg-orange-600 hover:bg-orange-700 text-white"
+                            }
+                          >
+                            Confirmar
+                          </Button>
+                        </div>
                       </div>
+                      {pendingDecision === "negado" && (
+                        <RejectionReasonInput
+                          value={rejectionReason}
+                          onChange={setRejectionReason}
+                        />
+                      )}
                     </div>
                   ) : (
                     <div className="flex gap-2 justify-end">

--- a/new-site/packages/front-backoffice/src/pages/PapfeDocuments/index.tsx
+++ b/new-site/packages/front-backoffice/src/pages/PapfeDocuments/index.tsx
@@ -11,6 +11,7 @@ import { useNotification } from "@/contexts/NotificationContext";
 import { useHasPermission } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { RejectionReasonInput } from "@/components/RejectionReasonInput";
 import { Eye } from "lucide-react";
 import {
   Dialog,
@@ -76,6 +77,8 @@ export default function PapfeDocuments() {
   const [loading, setLoading] = useState(true);
   const [modal, setModal] = useState<ModalState>({ open: false });
   const [approving, setApproving] = useState(false);
+  const [rejecting, setRejecting] = useState(false);
+  const [rejectionReason, setRejectionReason] = useState("");
 
   const rows = useMemo(() => documents.map(toRow), [documents]);
 
@@ -96,6 +99,8 @@ export default function PapfeDocuments() {
   }, [fetchDocuments]);
 
   const openModal = async (doc: PapfeDocumentInfo) => {
+    setRejecting(false);
+    setRejectionReason("");
     setModal({ open: true, doc, blobUrl: null, loading: true });
     try {
       const blob = await papfeAPI.getDocument(doc.user_number);
@@ -110,6 +115,8 @@ export default function PapfeDocuments() {
   const closeModal = () => {
     if (modal.open && modal.blobUrl) URL.revokeObjectURL(modal.blobUrl);
     setModal({ open: false });
+    setRejecting(false);
+    setRejectionReason("");
   };
 
   const handleAction = (item: CrudItemType) => {
@@ -119,14 +126,24 @@ export default function PapfeDocuments() {
 
   const handleApproval = async (approved: boolean) => {
     if (!modal.open) return;
+    if (!approved && !rejectionReason.trim()) {
+      showNotification("Informe o motivo da rejeição.", "warning");
+      return;
+    }
     setApproving(true);
     try {
-      await papfeAPI.approve(modal.doc.user_number, approved);
-      const updatedDoc = { ...modal.doc, is_approved: approved };
+      await papfeAPI.approve(modal.doc.user_number, approved, rejectionReason);
+      const updatedDoc = {
+        ...modal.doc,
+        is_approved: approved,
+        rejection_reason: approved ? null : rejectionReason.trim(),
+      };
       setDocuments((prev) =>
         prev.map((d) => (d.id === modal.doc.id ? updatedDoc : d))
       );
       setModal({ ...modal, doc: updatedDoc });
+      setRejecting(false);
+      setRejectionReason("");
       showNotification(
         approved ? "Comprovante aprovado!" : "Comprovante rejeitado.",
         approved ? "success" : "warning"
@@ -192,6 +209,18 @@ export default function PapfeDocuments() {
                 <StatusBadge value={modal.doc.is_approved} />
               </div>
 
+              {modal.doc.is_approved === false &&
+                modal.doc.rejection_reason && (
+                  <div className="space-y-1.5">
+                    <p className="text-sm text-muted-foreground">
+                      Motivo da rejeição
+                    </p>
+                    <p className="text-sm text-foreground whitespace-pre-line rounded-lg border border-border bg-muted/30 p-3">
+                      {modal.doc.rejection_reason}
+                    </p>
+                  </div>
+                )}
+
               <div className="w-full h-[60vh] rounded-lg overflow-hidden border border-border bg-muted/30">
                 {modal.loading ? (
                   <div className="flex items-center justify-center h-full">
@@ -207,22 +236,53 @@ export default function PapfeDocuments() {
               </div>
 
               {canWrite && (
-                <DialogFooter>
-                  <Button
-                    variant="outline"
-                    onClick={() => handleApproval(false)}
-                    disabled={approving}
-                    className="border-red-500/40 text-red-400 hover:bg-red-500/10"
-                  >
-                    Rejeitar
-                  </Button>
-                  <Button
-                    onClick={() => handleApproval(true)}
-                    disabled={approving || modal.doc.is_approved === true}
-                    className="bg-emerald-600 hover:bg-emerald-700 text-white"
-                  >
-                    Aprovar
-                  </Button>
+                <DialogFooter className="flex-col items-stretch gap-3 sm:flex-col sm:items-stretch">
+                  {rejecting ? (
+                    <div className="flex flex-col gap-3">
+                      <RejectionReasonInput
+                        value={rejectionReason}
+                        onChange={setRejectionReason}
+                      />
+                      <div className="flex gap-2 justify-end">
+                        <Button
+                          variant="ghost"
+                          onClick={() => {
+                            setRejecting(false);
+                            setRejectionReason("");
+                          }}
+                          disabled={approving}
+                          className="text-muted-foreground"
+                        >
+                          Cancelar
+                        </Button>
+                        <Button
+                          onClick={() => handleApproval(false)}
+                          disabled={approving}
+                          className="bg-red-600 hover:bg-red-700 text-white"
+                        >
+                          Confirmar rejeição
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="flex gap-2 justify-end">
+                      <Button
+                        variant="outline"
+                        onClick={() => setRejecting(true)}
+                        disabled={approving || modal.doc.is_approved === false}
+                        className="border-red-500/40 text-red-400 hover:bg-red-500/10"
+                      >
+                        Rejeitar
+                      </Button>
+                      <Button
+                        onClick={() => handleApproval(true)}
+                        disabled={approving || modal.doc.is_approved === true}
+                        className="bg-emerald-600 hover:bg-emerald-700 text-white"
+                      >
+                        Aprovar
+                      </Button>
+                    </div>
+                  )}
                 </DialogFooter>
               )}
             </>

--- a/new-site/packages/front-backoffice/src/types/AbsenceJustificationType.ts
+++ b/new-site/packages/front-backoffice/src/types/AbsenceJustificationType.ts
@@ -16,4 +16,5 @@ export type AbsenceJustificationType = {
   attachment_content_type: string;
   submitted_at: string;
   status: AbsenceJustificationStatus;
+  rejection_reason?: string | null;
 };

--- a/new-site/packages/front-site/src/api/client.ts
+++ b/new-site/packages/front-site/src/api/client.ts
@@ -13,7 +13,7 @@ const UNAUTHENTICATED_ENDPOINTS = [
 
 const client: AxiosInstance = axios.create({
   baseURL: BASEURL,
-  timeout: 10000,
+  timeout: 30000,
   withCredentials: true,
   headers: {
     "Content-Type": "application/json",

--- a/new-site/packages/front-site/src/api/index.ts
+++ b/new-site/packages/front-site/src/api/index.ts
@@ -9,7 +9,9 @@ export type {
   SubmitJustificationInput,
   UpdateJustificationInput,
 } from "./absenceJustifications";
+export { papfeAPI } from "./papfe";
 export type { AbsenceJustificationType, AbsenceJustificationStatus } from "@/types/AbsenceJustificationType";
+export type { PapfeDocumentType } from "@/types/PapfeDocumentType";
 export { default as client } from "./client";
 export type { LoginResponse, RegisterResponse, ProfileResponse, ApiError } from "@/types/APIResponseType";
 export { productsAPI } from "./products";

--- a/new-site/packages/front-site/src/api/papfe.ts
+++ b/new-site/packages/front-site/src/api/papfe.ts
@@ -1,0 +1,25 @@
+import client from "./client";
+import type { PapfeDocumentType } from "@/types/PapfeDocumentType";
+
+/**
+ * Endpoints do comprovante PAPFE (participante).
+ *
+ *   GET /api/papfe-document
+ *     Retorna os metadados do comprovante PAPFE do usuário autenticado
+ *     (404 -> null). Inclui `rejection_reason` apenas quando rejeitado.
+ */
+export const papfeAPI = {
+  getMine: async (): Promise<PapfeDocumentType | null> => {
+    try {
+      const response = await client.get<{ papfe_document: PapfeDocumentType }>(
+        "/api/papfe-document"
+      );
+      return response.data.papfe_document;
+    } catch (err) {
+      if ((err as { response?: { status?: number } }).response?.status === 404) {
+        return null;
+      }
+      throw err;
+    }
+  },
+};

--- a/new-site/packages/front-site/src/components/JustifyAbsenceModal.tsx
+++ b/new-site/packages/front-site/src/components/JustifyAbsenceModal.tsx
@@ -241,6 +241,18 @@ export default function JustifyAbsenceModal({
             </p>
           </div>
 
+          {justification!.status === "negado" &&
+            justification!.rejection_reason && (
+              <div>
+                <p className="mb-1.5 text-sm font-semibold text-gray-700 dark:text-gray-200">
+                  Motivo da negativa
+                </p>
+                <p className="w-full whitespace-pre-line rounded-md border border-red-700/30 bg-red-700/10 p-3 text-base text-gray-900 dark:border-red-500/40 dark:bg-red-500/10 dark:text-gray-100">
+                  {justification!.rejection_reason}
+                </p>
+              </div>
+            )}
+
           <p className="text-xs text-gray-500 dark:text-gray-400">
             {justification!.status === "aprovado"
               ? "Sua justificativa foi aprovada."

--- a/new-site/packages/front-site/src/components/PapfeStatusBadge.tsx
+++ b/new-site/packages/front-site/src/components/PapfeStatusBadge.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@/lib/utils";
+import type { PapfeStatus } from "@/types/PapfeDocumentType";
+
+const STATUS_LABEL: Record<PapfeStatus, string> = {
+  aprovado: "Aprovado",
+  rejeitado: "Rejeitado",
+  pendente: "Pendente",
+};
+
+const STATUS_BADGE_CLASS: Record<PapfeStatus, string> = {
+  aprovado: "bg-emerald-700 text-white border-emerald-800",
+  rejeitado: "bg-red-700 text-white border-red-800",
+  pendente: "bg-amber-600 text-white border-amber-700",
+};
+
+export function PapfeStatusBadge({ status }: { status: PapfeStatus }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium",
+        STATUS_BADGE_CLASS[status]
+      )}
+    >
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}
+
+export { STATUS_LABEL as PAPFE_STATUS_LABEL };

--- a/new-site/packages/front-site/src/components/RejectionReasonModal.tsx
+++ b/new-site/packages/front-site/src/components/RejectionReasonModal.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from "react";
+import Modal from "@/components/ui/Modal";
+
+type RejectionReasonModalProps = {
+  open: boolean;
+  onClose: () => void;
+  /** Título curto, ex: "Comprovante PAPFE" ou "Justificativa de ausência". */
+  title: string;
+  /** Badge de status já renderizado pelo chamador. */
+  statusBadge: ReactNode;
+  /** Motivo da negativa/rejeição (só existe quando negado). */
+  rejectionReason: string;
+};
+
+/**
+ * Modal reutilizável que exibe o status de um documento e o motivo da negativa
+ * registrado pela organização. Usado tanto para o PAPFE quanto para a
+ * justificativa de ausência.
+ */
+export default function RejectionReasonModal({
+  open,
+  onClose,
+  title,
+  statusBadge,
+  rejectionReason,
+}: RejectionReasonModalProps) {
+  return (
+    <Modal open={open} onClose={onClose} title={title} size="sm">
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-gray-500 dark:text-gray-400">
+            Status:
+          </span>
+          {statusBadge}
+        </div>
+
+        {rejectionReason.trim() ? (
+          <div>
+            <p className="mb-1.5 text-sm font-semibold text-gray-700 dark:text-gray-200">
+              Motivo da negativa
+            </p>
+            <p className="w-full whitespace-pre-line text-base text-gray-900 dark:text-gray-100">
+              {rejectionReason}
+            </p>
+          </div>
+        ) : (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Nenhum motivo registrado.
+          </p>
+        )}
+
+        <button
+          onClick={onClose}
+          className="mt-1 rounded-lg bg-semcompDarkBlue px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-semcompMidDarkBlue dark:bg-semcompOffWhite dark:text-semcompDarkBlue dark:hover:bg-white"
+        >
+          Fechar
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/new-site/packages/front-site/src/pages/Profile/index.tsx
+++ b/new-site/packages/front-site/src/pages/Profile/index.tsx
@@ -4,15 +4,19 @@ import useWindowDimensions from "@/hooks/useWindowDimensions";
 import { useTheme } from "@/contexts/useTheme";
 import ContatoSection from "../Home/sections/ContatoSection";
 import { useAuth } from "@/contexts/AuthContext";
-import { authAPI, absenceJustificationsAPI } from "@/api";
-import { ChevronDown } from "lucide-react";
+import { authAPI, absenceJustificationsAPI, papfeAPI } from "@/api";
+import { ChevronDown, Eye } from "lucide-react";
 import { useNotification } from "@/contexts/NotificationContext";
 import type { EventType } from "@/types/EventType"
 import type { UserType } from "@/types/UserType"
+import type { PapfeDocumentType } from "@/types/PapfeDocumentType"
+import { papfeStatusOf } from "@/types/PapfeDocumentType"
 import { formatTime, formatDate, formatWeekDay } from "@/lib/utils/formatDate"
 import { useNavigate } from "react-router-dom";
 import JustifyAbsenceModal, { JustifyAbsenceStatusBadge } from "@/components/JustifyAbsenceModal";
 import type { JustifyAbsenceStatus } from "@/components/JustifyAbsenceModal";
+import { PapfeStatusBadge } from "@/components/PapfeStatusBadge";
+import RejectionReasonModal from "@/components/RejectionReasonModal";
 
 const HERO_IMAGES = [
   "/img/Home/Hero/Banner1.webp",
@@ -29,6 +33,20 @@ const pickRandomHero = () =>
 type Evento = EventType & {
   linkInscricao?: string;
 };
+
+function StatusEyeButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      aria-label="Ver motivo da negativa"
+      title="Ver motivo da negativa"
+      className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-semcompDarkBlue text-white transition-colors hover:bg-semcompMidDarkBlue dark:bg-semcompOffWhite dark:text-semcompDarkBlue dark:hover:bg-white"
+    >
+      <Eye className="w-4 h-4" />
+    </button>
+  );
+}
+
 
 const events: Evento[] = [
 ];
@@ -55,6 +73,10 @@ export default function Profile({
   const [openSubscription, setOpenSubscription] = useState<number>(-1)
   const [justifyOpen, setJustifyOpen] = useState(false)
   const [justificationStatus, setJustificationStatus] = useState<JustifyAbsenceStatus | null>(null)
+  const [absenceRejectionReason, setAbsenceRejectionReason] = useState("")
+  const [hasPapfe, setHasPapfe] = useState(false)
+  const [papfeDoc, setPapfeDoc] = useState<PapfeDocumentType | null>(null)
+  const [reasonModal, setReasonModal] = useState<"papfe" | "absence" | null>(null)
 
   // Justificativas "Aprovado" ou "Negado" são finais e não podem ser editadas.
   const justificationLocked =
@@ -66,6 +88,7 @@ export default function Profile({
 
   const handleJustifySubmitted = (status: JustifyAbsenceStatus) => {
     setJustificationStatus(status);
+    setAbsenceRejectionReason("");
   };
 
   useEffect(() => {
@@ -81,9 +104,21 @@ export default function Profile({
         setUserEmail(response.email || email);
         setUserCode(response.user_number || 0);
         setPresencePercent(response.presence_rate ?? 0);
+        setHasPapfe(response.hasPapfe ?? false);
 
         const mine = await absenceJustificationsAPI.getMine();
-        if (mine) setJustificationStatus(mine.status);
+        if (mine) {
+          setJustificationStatus(mine.status);
+          if (mine.status === "negado")
+            setAbsenceRejectionReason(mine.rejection_reason ?? "");
+        }
+
+        if (response.hasPapfe) {
+          const doc = await papfeAPI.getMine();
+          setPapfeDoc(doc);
+        } else {
+          setPapfeDoc(null);
+        }
       } catch (err) {
         console.error("Erro ao buscar o perfil", err);
         await logout();
@@ -222,8 +257,31 @@ export default function Profile({
                   Justificar Ausência
                 </button>
                 {justificationStatus && (
-                  <div className="flex items-center justify-center mb-6">
+                  <div className="flex items-center justify-center gap-2 mb-6">
                     <JustifyAbsenceStatusBadge status={justificationStatus} />
+                    {justificationStatus === "negado" &&
+                      absenceRejectionReason && (
+                        <StatusEyeButton
+                          onClick={() => setReasonModal("absence")}
+                        />
+                      )}
+                  </div>
+                )}
+
+                {hasPapfe && (
+                  <div className="flex items-center justify-between gap-2 rounded-lg bg-white/50 border border-black/10 px-3 py-2 mb-6">
+                    <span className="text-sm font-semibold text-semcompDarkBlue">
+                      Comprovante PAPFE
+                    </span>
+                    <div className="flex items-center gap-2">
+                      <PapfeStatusBadge status={papfeStatusOf(papfeDoc)} />
+                      {papfeDoc?.is_approved === false &&
+                        papfeDoc.rejection_reason && (
+                          <StatusEyeButton
+                            onClick={() => setReasonModal("papfe")}
+                          />
+                        )}
+                    </div>
                   </div>
                 )}
 
@@ -301,6 +359,22 @@ export default function Profile({
 
         <ContatoSection />
         <JustifyAbsenceModal open={justifyOpen} onClose={() => setJustifyOpen(false)} onSubmitted={handleJustifySubmitted} />
+        <RejectionReasonModal
+          open={reasonModal === "absence"}
+          onClose={() => setReasonModal(null)}
+          title="Justificativa de ausência"
+          statusBadge={
+            <JustifyAbsenceStatusBadge status={justificationStatus ?? "em_analise"} />
+          }
+          rejectionReason={absenceRejectionReason}
+        />
+        <RejectionReasonModal
+          open={reasonModal === "papfe"}
+          onClose={() => setReasonModal(null)}
+          title="Comprovante PAPFE"
+          statusBadge={<PapfeStatusBadge status={papfeStatusOf(papfeDoc)} />}
+          rejectionReason={papfeDoc?.rejection_reason ?? ""}
+        />
       </div>
     );
   }
@@ -396,8 +470,26 @@ export default function Profile({
             Justificar Ausência
           </button>
           {justificationStatus && (
-            <div className="flex items-center justify-center mb-8">
+            <div className="flex items-center justify-center gap-2 mb-8">
               <JustifyAbsenceStatusBadge status={justificationStatus} />
+              {justificationStatus === "negado" && absenceRejectionReason && (
+                <StatusEyeButton onClick={() => setReasonModal("absence")} />
+              )}
+            </div>
+          )}
+
+          {hasPapfe && (
+            <div className="flex items-center justify-between gap-2 rounded-xl border border-border/50 bg-semcompOffWhite/40 px-3 py-2 mb-8">
+              <span className="text-sm font-semibold text-semcompMidDarkBlue">
+                Comprovante PAPFE
+              </span>
+              <div className="flex items-center gap-2">
+                <PapfeStatusBadge status={papfeStatusOf(papfeDoc)} />
+                {papfeDoc?.is_approved === false &&
+                  papfeDoc.rejection_reason && (
+                    <StatusEyeButton onClick={() => setReasonModal("papfe")} />
+                  )}
+              </div>
             </div>
           )}
 
@@ -542,6 +634,22 @@ export default function Profile({
 
         <ContatoSection />
         <JustifyAbsenceModal open={justifyOpen} onClose={() => setJustifyOpen(false)} onSubmitted={handleJustifySubmitted} />
+        <RejectionReasonModal
+          open={reasonModal === "absence"}
+          onClose={() => setReasonModal(null)}
+          title="Justificativa de ausência"
+          statusBadge={
+            <JustifyAbsenceStatusBadge status={justificationStatus ?? "em_analise"} />
+          }
+          rejectionReason={absenceRejectionReason}
+        />
+        <RejectionReasonModal
+          open={reasonModal === "papfe"}
+          onClose={() => setReasonModal(null)}
+          title="Comprovante PAPFE"
+          statusBadge={<PapfeStatusBadge status={papfeStatusOf(papfeDoc)} />}
+          rejectionReason={papfeDoc?.rejection_reason ?? ""}
+        />
       </div>
     );
   }
@@ -553,6 +661,22 @@ export default function Profile({
         {qrAndAccountCard}
       </div>
       <JustifyAbsenceModal open={justifyOpen} onClose={() => setJustifyOpen(false)} onSubmitted={handleJustifySubmitted} />
+      <RejectionReasonModal
+        open={reasonModal === "absence"}
+        onClose={() => setReasonModal(null)}
+        title="Justificativa de ausência"
+        statusBadge={
+          <JustifyAbsenceStatusBadge status={justificationStatus ?? "em_analise"} />
+        }
+        rejectionReason={absenceRejectionReason}
+      />
+      <RejectionReasonModal
+        open={reasonModal === "papfe"}
+        onClose={() => setReasonModal(null)}
+        title="Comprovante PAPFE"
+        statusBadge={<PapfeStatusBadge status={papfeStatusOf(papfeDoc)} />}
+        rejectionReason={papfeDoc?.rejection_reason ?? ""}
+      />
     </div>
   );
 }

--- a/new-site/packages/front-site/src/types/APIResponseType.ts
+++ b/new-site/packages/front-site/src/types/APIResponseType.ts
@@ -29,6 +29,7 @@ export interface ProfileResponse {
   email: string;
   name: string;
   presence_rate: number;
+  hasPapfe?: boolean;
 }
 
 export interface ForgotPasswordResponse {

--- a/new-site/packages/front-site/src/types/AbsenceJustificationType.ts
+++ b/new-site/packages/front-site/src/types/AbsenceJustificationType.ts
@@ -16,4 +16,6 @@ export type AbsenceJustificationType = {
   attachment_content_type: string;
   submitted_at: string;
   status: AbsenceJustificationStatus;
+  /** Só presente quando status="negado". */
+  rejection_reason?: string | null;
 };

--- a/new-site/packages/front-site/src/types/PapfeDocumentType.ts
+++ b/new-site/packages/front-site/src/types/PapfeDocumentType.ts
@@ -1,0 +1,21 @@
+export type PapfeStatus = "aprovado" | "rejeitado" | "pendente";
+
+export type PapfeDocumentType = {
+  id: number;
+  user_number: number;
+  user_name: string;
+  user_email: string;
+  filename: string;
+  content_type: string;
+  uploaded_at: string;
+  is_approved: boolean | null; // null=pendente, true=aprovado, false=rejeitado
+  /** Só presente quando is_approved=false (rejeitado). */
+  rejection_reason?: string | null;
+};
+
+export const papfeStatusOf = (doc: PapfeDocumentType | null): PapfeStatus =>
+  doc == null || doc.is_approved === null
+    ? "pendente"
+    : doc.is_approved
+      ? "aprovado"
+      : "rejeitado";


### PR DESCRIPTION
Permite que seja informado o motivo da negativa ao reprovar justificativas de ausência e comprovantes PAPFE, e que o participante visualize esse motivo no perfil.

### Backend
- Novo campo `rejection_reason`: obrigatório ao negar/rejeitar, limpo quando o status muda.
- Novo endpoint `GET /api/papfe-document` (metadados do comprovante do usuário).
- E-mail de verificação passa a ser enviado de forma assíncrona.

### Backoffice
- Componente `RejectionReasonInput` reutilizável (motivo obrigatório ao negar).
- Motivo exibido nos modais de justificativa e PAPFE.

### Site do participante
- `papfeAPI.getMine` + badges de status do PAPFE no perfil.
- Modal reutilizável para exibir o motivo da negativa.