### PR TITLE
feat(riddles): implementa backoffice de riddles com CRUD, upload de C…

### DIFF
--- a/new-site/packages/backend/cmd/api/main.go
+++ b/new-site/packages/backend/cmd/api/main.go
@@ -18,6 +18,7 @@ import (
 	"backend/internal/presence"
 	"backend/internal/product"
 	"backend/internal/providers"
+	"backend/internal/riddle"
 	"backend/internal/sales"
 	"backend/internal/sitestat"
 	"backend/internal/sponsor"
@@ -59,6 +60,7 @@ func main() {
 		&product.Product{}, &product.Kit{}, &product.Coffee{}, &product.ComboItem{},
 		&token.Token{}, &sponsor.Sponsor{}, &sponsor.SponsorPackage{},
 		&sitestat.SiteStat{}, &sales.Sale{}, &sales.SaleItem{}, &sales.ConsumedItem{},
+		&riddle.Riddle{},
 	)
 	if err != nil {
 		panic("Failed to migrate database: " + err.Error())
@@ -125,6 +127,10 @@ func main() {
 	eventRepo := event.NewEventRepository(db)
 	eventService := event.NewEventService(eventRepo)
 	eventHandler := event.NewEventHandler(eventService)
+
+	riddleRepo := riddle.NewRiddleRepository(db)
+	riddleService := riddle.NewRiddleService(riddleRepo)
+	riddleHandler := riddle.NewRiddleHandler(riddleService)
 
 	presenceRepo := presence.NewPresenceRepository(db)
 	presenceService := presence.NewPresenceService(presenceRepo)
@@ -295,6 +301,14 @@ func main() {
 	// GET nos eventos - Consulta pública via GET /events
 	admin.PUT("/events/:eventName/:initDate", permMW("Eventos", permission.PermRW), eventHandler.UpdateEventByNameAndInitDate)
 	admin.DELETE("/events/:eventName/:initDate", permMW("Eventos", permission.PermRW), eventHandler.DeleteEventByNameAndInitDate)
+
+	// Riddles
+	admin.GET("/riddles", permMW("Riddles", permission.PermR), riddleHandler.GetRiddles)
+	admin.GET("/riddles/:id", permMW("Riddles", permission.PermR), riddleHandler.GetRiddleByID)
+	admin.POST("/riddles", permMW("Riddles", permission.PermRW), riddleHandler.CreateRiddle)
+	admin.POST("/riddles/upload-csv", permMW("Riddles", permission.PermRW), riddleHandler.UploadRiddlesCSV)
+	admin.PUT("/riddles/:id", permMW("Riddles", permission.PermRW), riddleHandler.UpdateRiddle)
+	admin.DELETE("/riddles/:id", permMW("Riddles", permission.PermRW), riddleHandler.DeleteRiddle)
 
 	// Participações
 	admin.GET("/presences", permMW("Participações", permission.PermR), presenceHandler.GetPresences)

--- a/new-site/packages/backend/internal/permission/model.go
+++ b/new-site/packages/backend/internal/permission/model.go
@@ -35,6 +35,7 @@ var KnownSections = []string{
 	"Patrocinadores",
 	"Vendas",
 	"PAPFE",
+	"Riddles",
 }
 
 type Permission struct {

--- a/new-site/packages/backend/internal/riddle/handler.go
+++ b/new-site/packages/backend/internal/riddle/handler.go
@@ -1,0 +1,250 @@
+package riddle
+
+import (
+	"net/http"
+	"strconv"
+
+	"backend/internal/apierrors"
+
+	"github.com/gin-gonic/gin"
+)
+
+type RiddleHandler struct {
+	riddleService RiddleService
+}
+
+func NewRiddleHandler(riddleService RiddleService) *RiddleHandler {
+	return &RiddleHandler{riddleService: riddleService}
+}
+
+func parseRiddleID(c *gin.Context) (uint, error) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return uint(id), nil
+}
+
+// CreateRiddle processa o payload JSON e cria um novo riddle no final da fila.
+// @Summary Cria um novo riddle
+// @Description Cadastra um enigma no sistema, sempre ao final da fila atual
+// @Tags Riddle Backoffice
+// @Accept json
+// @Produce json
+// @Param request body riddle.CreateRiddleRequest true "Dados do riddle"
+// @Success 201 {object} map[string]interface{} "Riddle criado com sucesso!"
+// @Failure 400 {object} map[string]string "Dados inválidos"
+// @Failure 500 {object} map[string]string "Erro interno"
+// @Security BearerAuth
+// @Router /admin/riddles [post]
+func (h *RiddleHandler) CreateRiddle(c *gin.Context) {
+	var request CreateRiddleRequest
+
+	if err := c.ShouldBindJSON(&request); err != nil {
+		apierrors.HandleAPIError(c, apierrors.ValidationError("Dados inválidos", err))
+		return
+	}
+
+	riddle, err := h.riddleService.CreateRiddle(request)
+	if err != nil {
+		apierrors.HandleAPIError(c, err)
+		return
+	}
+	c.Set("responseMessage", "Riddle criado com sucesso!")
+	c.JSON(http.StatusCreated, gin.H{"message": "Riddle criado com sucesso!", "riddle": riddle})
+}
+
+// GetRiddleByID retorna um riddle específico pelo ID.
+// @Summary Busca riddle por ID
+// @Description Retorna os dados de um riddle específico
+// @Tags Riddle Backoffice
+// @Accept json
+// @Produce json
+// @Param id path int true "ID do riddle"
+// @Success 200 {object} riddle.Riddle "Riddle encontrado"
+// @Failure 400 {object} map[string]string "ID inválido"
+// @Failure 404 {object} map[string]string "Riddle não encontrado"
+// @Failure 500 {object} map[string]string "Erro interno"
+// @Security BearerAuth
+// @Router /admin/riddles/{id} [get]
+func (h *RiddleHandler) GetRiddleByID(c *gin.Context) {
+	id, err := parseRiddleID(c)
+	if err != nil {
+		apierrors.HandleAPIError(c, apierrors.ValidationError("ID inválido", err))
+		return
+	}
+
+	riddle, err := h.riddleService.GetRiddleByID(id)
+	if err != nil {
+		apierrors.HandleAPIError(c, err)
+		return
+	}
+	c.Set("responseMessage", "Riddle encontrado com sucesso!")
+	c.JSON(http.StatusOK, riddle)
+}
+
+// UpdateRiddle atualiza os dados de um riddle existente (incluindo o toggle IsActive).
+// @Summary Atualiza riddle
+// @Description Altera os dados de um riddle existente, incluindo ativação/desativação
+// @Tags Riddle Backoffice
+// @Accept json
+// @Produce json
+// @Param id path int true "ID do riddle"
+// @Param request body riddle.UpdateRiddleRequest true "Dados para atualização"
+// @Success 200 {object} map[string]interface{} "Riddle atualizado com sucesso"
+// @Failure 400 {object} map[string]string "Dados inválidos ou ID inválido"
+// @Failure 404 {object} map[string]string "Riddle não encontrado"
+// @Failure 500 {object} map[string]string "Erro interno"
+// @Security BearerAuth
+// @Router /admin/riddles/{id} [put]
+func (h *RiddleHandler) UpdateRiddle(c *gin.Context) {
+	id, err := parseRiddleID(c)
+	if err != nil {
+		apierrors.HandleAPIError(c, apierrors.ValidationError("ID inválido", err))
+		return
+	}
+
+	var request UpdateRiddleRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		apierrors.HandleAPIError(c, apierrors.ValidationError("Dados inválidos", err))
+		return
+	}
+
+	riddle, err := h.riddleService.UpdateRiddle(id, request)
+	if err != nil {
+		apierrors.HandleAPIError(c, err)
+		return
+	}
+
+	c.Set("responseMessage", "Riddle atualizado com sucesso!")
+	c.JSON(http.StatusOK, gin.H{"message": "Riddle atualizado com sucesso!", "riddle": riddle})
+}
+
+// DeleteRiddle remove logicamente um riddle (soft delete), sem alterar a ordem dos demais.
+// @Summary Remove riddle (soft delete)
+// @Description Marca um riddle como inativo; nunca apaga a linha do banco
+// @Tags Riddle Backoffice
+// @Accept json
+// @Produce json
+// @Param id path int true "ID do riddle"
+// @Success 200 {object} map[string]string "Riddle removido com sucesso"
+// @Failure 400 {object} map[string]string "ID inválido"
+// @Failure 404 {object} map[string]string "Riddle não encontrado"
+// @Failure 500 {object} map[string]string "Erro interno"
+// @Security BearerAuth
+// @Router /admin/riddles/{id} [delete]
+func (h *RiddleHandler) DeleteRiddle(c *gin.Context) {
+	id, err := parseRiddleID(c)
+	if err != nil {
+		apierrors.HandleAPIError(c, apierrors.ValidationError("ID inválido", err))
+		return
+	}
+
+	if err := h.riddleService.DeleteRiddle(id); err != nil {
+		apierrors.HandleAPIError(c, err)
+		return
+	}
+	c.Set("responseMessage", "Riddle removido com sucesso!")
+	c.JSON(http.StatusOK, gin.H{"message": "Riddle removido com sucesso!"})
+}
+
+// GetRiddles retorna a lista paginada de riddles (ativos e inativos) com suporte a filtros e ordenação.
+// @Summary Lista riddles
+// @Description Retorna uma lista paginada de riddles cadastrados, incluindo os inativos
+// @Tags Riddle Backoffice
+// @Accept json
+// @Produce json
+// @Param page query int false "Página atual" default(1)
+// @Param limit query int false "Limite de itens por página" default(10)
+// @Param sort_by query string false "Campo de ordenação" default(id)
+// @Param sort_order query string false "Ordem (asc/desc)" default(asc)
+// @Param search_by query string false "Campo de busca"
+// @Param search_value query string false "Valor de busca"
+// @Success 200 {object} map[string]interface{} "Lista de riddles paginada"
+// @Failure 400 {object} map[string]string "Parâmetro inválido"
+// @Failure 500 {object} map[string]string "Erro interno"
+// @Security BearerAuth
+// @Router /admin/riddles [get]
+func (h *RiddleHandler) GetRiddles(c *gin.Context) {
+	page := 1
+	limit := 10
+	sortBy := c.DefaultQuery("sort_by", "id")
+	sortOrder := c.DefaultQuery("sort_order", "asc")
+	searchBy := c.Query("search_by")
+	searchValue := c.Query("search_value")
+
+	if pageQuery := c.Query("page"); pageQuery != "" {
+		parsedPage, err := strconv.Atoi(pageQuery)
+		if err != nil {
+			apierrors.HandleAPIError(c, apierrors.ValidationError("Parâmetro 'page' inválido", err))
+			return
+		}
+		page = parsedPage
+	}
+
+	if limitQuery := c.Query("limit"); limitQuery != "" {
+		parsedLimit, err := strconv.Atoi(limitQuery)
+		if err != nil {
+			apierrors.HandleAPIError(c, apierrors.ValidationError("Parâmetro 'limit' inválido", err))
+			return
+		}
+		limit = parsedLimit
+	}
+
+	result, err := h.riddleService.GetRiddles(page, limit, sortBy, sortOrder, searchBy, searchValue)
+	if err != nil {
+		apierrors.HandleAPIError(c, err)
+		return
+	}
+	c.Set("responseMessage", "Riddles listados com sucesso!")
+	c.JSON(http.StatusOK, gin.H{
+		"page":             page,
+		"limit":            limit,
+		"sort_by":          sortBy,
+		"sort_order":       sortOrder,
+		"search_by":        searchBy,
+		"search_value":     searchValue,
+		"total_records":    result.TotalRecords,
+		"filtered_records": result.FilteredRecords,
+		"riddles":          result.Riddles,
+	})
+}
+
+// UploadRiddlesCSV substitui totalmente a fila de riddles a partir de um CSV.
+// @Summary Importa riddles via CSV (substitui tudo)
+// @Description Recebe um CSV (título, subtítulo, resposta, link da imagem) e substitui totalmente o conjunto de riddles, na ordem das linhas do arquivo. Os riddles anteriores são apagados fisicamente do banco (hard delete), não apenas desativados.
+// @Tags Riddle Backoffice
+// @Accept multipart/form-data
+// @Produce json
+// @Param file formData file true "Arquivo CSV"
+// @Success 200 {object} map[string]interface{} "Riddles importados com sucesso"
+// @Failure 400 {object} map[string]string "Arquivo inválido ou CSV mal formatado"
+// @Failure 500 {object} map[string]string "Erro interno"
+// @Security BearerAuth
+// @Router /admin/riddles/upload-csv [post]
+func (h *RiddleHandler) UploadRiddlesCSV(c *gin.Context) {
+	fileHeader, err := c.FormFile("file")
+	if err != nil {
+		apierrors.HandleAPIError(c, apierrors.ValidationError("Arquivo 'file' é obrigatório", err))
+		return
+	}
+
+	file, err := fileHeader.Open()
+	if err != nil {
+		apierrors.HandleAPIError(c, apierrors.InternalServerError("Erro ao abrir o arquivo enviado", err))
+		return
+	}
+	defer file.Close()
+
+	riddles, err := h.riddleService.ReplaceRiddlesFromCSV(file)
+	if err != nil {
+		apierrors.HandleAPIError(c, err)
+		return
+	}
+
+	c.Set("responseMessage", "Riddles importados com sucesso!")
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Riddles importados com sucesso!",
+		"riddles": riddles,
+	})
+}

--- a/new-site/packages/backend/internal/riddle/model.go
+++ b/new-site/packages/backend/internal/riddle/model.go
@@ -14,13 +14,22 @@ const MaxTeamSize = 5
 // O ID do enigma é a sua posição na ordem: os enigmas devem ser resolvidos em
 // sequência (id 1, depois 2, 3, ...), nunca fora de ordem.
 type Riddle struct {
-	ID          uint      `gorm:"primaryKey;autoIncrement" json:"id"`
-	Hint1	    string    `gorm:"type:text;not null" json:"hint_1"`
-	Hint2	    string    `gorm:"type:text;not null" json:"hint_2"`
-	Answer      string    `gorm:"type:text;not null" json:"-"`
-	ImageURL    string    `gorm:"type:text" json:"image_url"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	ID    uint   `gorm:"primaryKey;autoIncrement" json:"id"`
+	Hint1 string `gorm:"type:text;not null" json:"hint_1"`
+	Hint2 string `gorm:"type:text;not null" json:"hint_2"`
+	// Answer é serializada normalmente aqui porque este struct hoje só é
+	// exposto pelas rotas de backoffice (que precisam ver/editar a resposta).
+	// Um futuro endpoint público pro participante jogar NÃO deve serializar
+	// este struct diretamente — deve usar um DTO próprio sem Answer, no mesmo
+	// padrão de user.SafeUser (que esconde PasswordHash).
+	Answer   string `gorm:"type:text;not null" json:"answer"`
+	ImageURL string `gorm:"type:text" json:"image_url"`
+	// IsActive controla tanto a exclusão lógica (soft delete) quanto a
+	// visibilidade do enigma para os participantes. "Último enigma" é sempre
+	// MAX(id) filtrando apenas os riddles com IsActive = true.
+	IsActive  bool      `gorm:"not null;default:true" json:"is_active"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // Team representa uma equipe de participantes jogando o jogo de enigmas.
@@ -28,8 +37,8 @@ type Riddle struct {
 // índice do próximo enigma a ser resolvido (CurrentRiddleIndex).
 // Quando CurrentRiddleIndex ultrapassa o último enigma, o time terminou o jogo.
 type Team struct {
-	ID                uint        `gorm:"primaryKey;autoIncrement" json:"id"`
-	Name              string      `gorm:"size:200;not null;uniqueIndex" json:"name"`
+	ID   uint   `gorm:"primaryKey;autoIncrement" json:"id"`
+	Name string `gorm:"size:200;not null;uniqueIndex" json:"name"`
 	// Índice (ID) do próximo enigma a resolver. 0 = ainda não resolveu o primeiro.
 	// Quando > maior ID de enigma, o time já resolveu todos (final riddle).
 	CurrentRiddleIndex uint       `gorm:"not null;default:0" json:"current_riddle_index"`
@@ -43,11 +52,11 @@ type Team struct {
 // TeamMember relaciona um participante (user.User) a uma equipe (Team).
 // O tamanho da equipe é limitado a MaxTeamSize membros.
 type TeamMember struct {
-	TeamID    uint      `gorm:"primaryKey;not null" json:"team_id"`
-	UserNumber uint     `gorm:"primaryKey;not null" json:"user_number"` // referencia user.User.UserNumber
-	JoinedAt  time.Time `json:"joined_at"`
+	TeamID     uint      `gorm:"primaryKey;not null" json:"team_id"`
+	UserNumber uint      `gorm:"primaryKey;not null" json:"user_number"` // referencia user.User.UserNumber
+	JoinedAt   time.Time `json:"joined_at"`
 
-	User *User `gorm:"foreignKey:UserNumber;references:UserNumber;constraint:OnDelete:CASCADE" json:"user,omitempty"`
+	User *user.User `gorm:"foreignKey:UserNumber;references:UserNumber;constraint:OnDelete:CASCADE" json:"user,omitempty"`
 }
 
 // --- Erros de domínio ---
@@ -66,9 +75,17 @@ type CreateRiddleRequest struct {
 	ImageURL string `json:"image_url"`
 }
 
+type UpdateRiddleRequest struct {
+	Hint1    string `json:"hint_1" binding:"required"`
+	Hint2    string `json:"hint_2" binding:"required"`
+	Answer   string `json:"answer" binding:"required"`
+	ImageURL string `json:"image_url"`
+	IsActive bool   `json:"is_active"`
+}
+
 type CreateTeamRequest struct {
-	Name    string   `json:"name" binding:"required,max=200"`
-	Members []uint   `json:"members" binding:"required,min=1,max=5"` // user_numbers dos participantes
+	Name    string `json:"name" binding:"required,max=200"`
+	Members []uint `json:"members" binding:"required,min=1,max=5"` // user_numbers dos participantes
 }
 
 type SolveRiddleRequest struct {

--- a/new-site/packages/backend/internal/riddle/repository.go
+++ b/new-site/packages/backend/internal/riddle/repository.go
@@ -1,0 +1,178 @@
+package riddle
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+type RiddleRepository interface {
+	Create(riddle *Riddle) error
+	GetByID(id uint) (*Riddle, error)
+	Update(id uint, riddle *Riddle) error
+	SoftDelete(id uint) error
+	GetRiddles(query RiddleListQuery) (*RiddleListResult, error)
+	ReplaceAll(newRiddles []*Riddle) ([]Riddle, error)
+}
+
+type riddleRepository struct {
+	db *gorm.DB
+}
+
+func NewRiddleRepository(db *gorm.DB) RiddleRepository {
+	return &riddleRepository{db: db}
+}
+
+func (r *riddleRepository) Create(riddle *Riddle) error {
+	return r.db.Create(riddle).Error
+}
+
+func (r *riddleRepository) GetByID(id uint) (*Riddle, error) {
+	var riddle Riddle
+	err := r.db.First(&riddle, id).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return &riddle, nil
+}
+
+// Update usa .Updates(map[...]) em vez de .Save()/update por struct: GORM
+// ignora campos zero-value (como IsActive=false) em updates por struct, o
+// que quebraria o soft delete via este mesmo método.
+func (r *riddleRepository) Update(id uint, riddle *Riddle) error {
+	result := r.db.Model(&Riddle{}).
+		Where("id = ?", id).
+		Updates(map[string]interface{}{
+			"hint1":     riddle.Hint1,
+			"hint2":     riddle.Hint2,
+			"answer":    riddle.Answer,
+			"image_url": riddle.ImageURL,
+			"is_active": riddle.IsActive,
+		})
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+
+	return nil
+}
+
+func (r *riddleRepository) SoftDelete(id uint) error {
+	result := r.db.Model(&Riddle{}).Where("id = ?", id).Update("is_active", false)
+	if result.Error != nil {
+		return result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+
+	return nil
+}
+
+func applySearchFilter(dbQuery *gorm.DB, query RiddleListQuery) *gorm.DB {
+	if query.SearchBy == "" || query.SearchValue == "" {
+		return dbQuery
+	}
+
+	switch query.SearchBy {
+	case "hint1":
+		return dbQuery.Where("hint1 ILIKE ?", "%"+query.SearchValue+"%")
+	case "hint2":
+		return dbQuery.Where("hint2 ILIKE ?", "%"+query.SearchValue+"%")
+	case "is_active":
+		return dbQuery.Where("is_active = ?", query.SearchValue)
+	default:
+		return dbQuery
+	}
+}
+
+func resolveSortClause(sortBy string, sortOrder string) (string, error) {
+	allowedSortFields := []string{"id", "hint1", "hint2", "is_active", "created_at"}
+
+	field := strings.ToLower(sortBy)
+	isAllowedField := slices.Contains(allowedSortFields, field)
+	if !isAllowedField {
+		return "", fmt.Errorf("invalid sort field")
+	}
+
+	order := strings.ToLower(sortOrder)
+	if order != "asc" && order != "desc" {
+		return "", fmt.Errorf("invalid sort order")
+	}
+
+	return field + " " + order, nil
+}
+
+func (r *riddleRepository) GetRiddles(query RiddleListQuery) (*RiddleListResult, error) {
+	var riddles []Riddle
+	var totalRecords int64
+	var filteredRecords int64
+
+	sortClause, err := resolveSortClause(query.SortBy, query.SortOrder)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := r.db.Model(&Riddle{}).Count(&totalRecords).Error; err != nil {
+		return nil, err
+	}
+
+	filteredQuery := applySearchFilter(r.db.Model(&Riddle{}), query)
+	if err := filteredQuery.Count(&filteredRecords).Error; err != nil {
+		return nil, err
+	}
+
+	dataQuery := applySearchFilter(r.db.Model(&Riddle{}), query)
+	err = dataQuery.Order(sortClause).Limit(query.Limit).Offset(query.Offset).Find(&riddles).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return &RiddleListResult{
+		Riddles:         riddles,
+		TotalRecords:    totalRecords,
+		FilteredRecords: filteredRecords,
+	}, nil
+}
+
+// ReplaceAll substitui totalmente a fila de riddles: apaga fisicamente (hard
+// delete) todos os riddles existentes e cria os novos, um a um e na ordem
+// recebida, garantindo que o autoincrement do ID preserve a ordem do CSV.
+//
+// Hard delete é seguro aqui porque, antes do início da competição, não há
+// nenhum registro de Team/TeamMember referenciando riddles — não existe risco
+// de FK ou perda de progresso de equipe ao apagar a fila anterior.
+func (r *riddleRepository) ReplaceAll(newRiddles []*Riddle) ([]Riddle, error) {
+	err := r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("1 = 1").Delete(&Riddle{}).Error; err != nil {
+			return err
+		}
+
+		for i := range newRiddles {
+			if err := tx.Create(newRiddles[i]).Error; err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	created := make([]Riddle, len(newRiddles))
+	for i, riddle := range newRiddles {
+		created[i] = *riddle
+	}
+
+	return created, nil
+}

--- a/new-site/packages/backend/internal/riddle/service.go
+++ b/new-site/packages/backend/internal/riddle/service.go
@@ -1,0 +1,223 @@
+package riddle
+
+import (
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"backend/internal/apierrors"
+
+	"gorm.io/gorm"
+)
+
+type RiddleService interface {
+	CreateRiddle(request CreateRiddleRequest) (*Riddle, error)
+	GetRiddleByID(id uint) (*Riddle, error)
+	UpdateRiddle(id uint, request UpdateRiddleRequest) (*Riddle, error)
+	DeleteRiddle(id uint) error
+	GetRiddles(page int, limit int, sortBy string, sortOrder string, searchBy string, searchValue string) (*RiddleListResult, error)
+	ReplaceRiddlesFromCSV(file io.Reader) ([]Riddle, error)
+}
+
+type riddleService struct {
+	repo RiddleRepository
+}
+
+func NewRiddleService(repo RiddleRepository) RiddleService {
+	return &riddleService{repo: repo}
+}
+
+// CreateRiddle sempre acrescenta o riddle no final da fila atual: o
+// autoincrement do ID garante isso sozinho, sem nenhuma lógica extra de
+// posicionamento.
+func (s *riddleService) CreateRiddle(request CreateRiddleRequest) (*Riddle, error) {
+	newRiddle := Riddle{
+		Hint1:    request.Hint1,
+		Hint2:    request.Hint2,
+		Answer:   request.Answer,
+		ImageURL: request.ImageURL,
+		IsActive: true,
+	}
+
+	if err := s.repo.Create(&newRiddle); err != nil {
+		return nil, apierrors.InternalServerError("Erro ao criar riddle", err)
+	}
+
+	return &newRiddle, nil
+}
+
+func (s *riddleService) GetRiddleByID(id uint) (*Riddle, error) {
+	riddle, err := s.repo.GetByID(id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, apierrors.NotFoundError("Riddle não encontrado", err)
+		}
+		return nil, apierrors.InternalServerError("Erro ao buscar riddle", err)
+	}
+
+	return riddle, nil
+}
+
+func (s *riddleService) UpdateRiddle(id uint, request UpdateRiddleRequest) (*Riddle, error) {
+	riddle := Riddle{
+		Hint1:    request.Hint1,
+		Hint2:    request.Hint2,
+		Answer:   request.Answer,
+		ImageURL: request.ImageURL,
+		IsActive: request.IsActive,
+	}
+
+	if err := s.repo.Update(id, &riddle); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, apierrors.NotFoundError("Riddle não encontrado", err)
+		}
+		return nil, apierrors.InternalServerError("Erro ao atualizar riddle", err)
+	}
+
+	return s.GetRiddleByID(id)
+}
+
+// DeleteRiddle nunca apaga a linha: apenas marca o riddle como inativo
+// (soft delete), preservando a ordem dos demais.
+func (s *riddleService) DeleteRiddle(id uint) error {
+	if err := s.repo.SoftDelete(id); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return apierrors.NotFoundError("Riddle não encontrado", err)
+		}
+		return apierrors.InternalServerError("Erro ao remover riddle", err)
+	}
+
+	return nil
+}
+
+func (s *riddleService) GetRiddles(page int, limit int, sortBy string, sortOrder string, searchBy string, searchValue string) (*RiddleListResult, error) {
+	if page < 1 {
+		return nil, apierrors.ValidationError("Page deve ser maior que 0", nil)
+	}
+
+	if limit < 1 {
+		return nil, apierrors.ValidationError("Limit deve ser maior que 0", nil)
+	}
+
+	if sortBy == "" {
+		sortBy = "id"
+	}
+
+	if sortOrder == "" {
+		sortOrder = "asc"
+	}
+
+	sortBy = strings.ToLower(sortBy)
+	sortOrder = strings.ToLower(sortOrder)
+
+	allowedSortFields := map[string]bool{
+		"id":         true,
+		"hint1":      true,
+		"hint2":      true,
+		"is_active":  true,
+		"created_at": true,
+	}
+
+	if !allowedSortFields[sortBy] {
+		return nil, apierrors.ValidationError("Parametro 'sort_by' inválido", nil)
+	}
+
+	if sortOrder != "asc" && sortOrder != "desc" {
+		return nil, apierrors.ValidationError("Parametro 'sort_order' inválido", nil)
+	}
+
+	if (searchBy == "" && searchValue != "") || (searchBy != "" && searchValue == "") {
+		return nil, apierrors.ValidationError("Parametro 'search_by' e 'search_value' devem ser fornecidos juntos", nil)
+	}
+
+	if searchBy != "" {
+		searchBy = strings.ToLower(searchBy)
+
+		allowedSearchFields := map[string]bool{
+			"hint1":     true,
+			"hint2":     true,
+			"is_active": true,
+		}
+
+		if !allowedSearchFields[searchBy] {
+			return nil, apierrors.ValidationError("Parametro 'search_by' inválido", nil)
+		}
+	}
+
+	offset := (page - 1) * limit
+	query := RiddleListQuery{
+		Limit:       limit,
+		Offset:      offset,
+		SortBy:      sortBy,
+		SortOrder:   sortOrder,
+		SearchBy:    searchBy,
+		SearchValue: searchValue,
+	}
+
+	return s.repo.GetRiddles(query)
+}
+
+// ReplaceRiddlesFromCSV lê o CSV completo (título, subtítulo, resposta, link
+// da imagem) e substitui totalmente a fila de riddles pelos novos, na ordem
+// das linhas do arquivo. Os riddles anteriores são apagados fisicamente
+// (hard delete), não apenas desativados — ver ReplaceAll.
+func (s *riddleService) ReplaceRiddlesFromCSV(file io.Reader) ([]Riddle, error) {
+	reader := csv.NewReader(file)
+	reader.FieldsPerRecord = -1
+
+	rows, err := reader.ReadAll()
+	if err != nil {
+		return nil, apierrors.ValidationError("Erro ao ler o arquivo CSV", err)
+	}
+
+	if len(rows) == 0 {
+		return nil, apierrors.ValidationError("CSV vazio", nil)
+	}
+
+	// Primeira linha é o cabeçalho.
+	dataRows := rows[1:]
+	if len(dataRows) == 0 {
+		return nil, apierrors.ValidationError("CSV não contém nenhuma linha de dados", nil)
+	}
+
+	newRiddles := make([]*Riddle, 0, len(dataRows))
+	for i, row := range dataRows {
+		lineNumber := i + 2 // +1 pelo cabeçalho, +1 porque a contagem é 1-based
+
+		if len(row) < 4 {
+			return nil, apierrors.ValidationError(
+				fmt.Sprintf("Linha %d do CSV inválida: esperado 4 colunas (título, subtítulo, resposta, link da imagem)", lineNumber),
+				nil,
+			)
+		}
+
+		title := strings.TrimSpace(row[0])
+		subtitle := strings.TrimSpace(row[1])
+		answer := strings.TrimSpace(row[2])
+		imageURL := strings.TrimSpace(row[3])
+
+		if title == "" || subtitle == "" || answer == "" {
+			return nil, apierrors.ValidationError(
+				fmt.Sprintf("Linha %d do CSV inválida: título, subtítulo e resposta são obrigatórios", lineNumber),
+				nil,
+			)
+		}
+
+		newRiddles = append(newRiddles, &Riddle{
+			Hint1:    title,
+			Hint2:    subtitle,
+			Answer:   answer,
+			ImageURL: imageURL,
+			IsActive: true,
+		})
+	}
+
+	created, err := s.repo.ReplaceAll(newRiddles)
+	if err != nil {
+		return nil, apierrors.InternalServerError("Erro ao substituir riddles a partir do CSV", err)
+	}
+
+	return created, nil
+}

--- a/new-site/packages/front-backoffice/src/api/index.ts
+++ b/new-site/packages/front-backoffice/src/api/index.ts
@@ -14,5 +14,6 @@ export { permissionsAPI } from "./permissions";
 export { pagesAPI } from "./pages";
 export { sponsorsAPI } from "./sponsors";
 export { salesAPI } from "./sales";
+export { riddlesAPI } from "./riddles";
 export { default as client } from "./client";
 export type { LoginResponse, RegisterResponse, ProfileResponse, ApiError } from "@/types/APIResponseType";

--- a/new-site/packages/front-backoffice/src/api/riddles.ts
+++ b/new-site/packages/front-backoffice/src/api/riddles.ts
@@ -1,0 +1,96 @@
+import client from "./client";
+import type { RiddleType } from "@/types/RiddleType";
+
+export interface RiddlesListResponse {
+  page: number;
+  limit: number;
+  sort_by: string;
+  sort_order: string;
+  search_by: string | null;
+  search_value: string | null;
+  total_records: number;
+  filtered_records: number;
+  riddles: RiddleType[];
+}
+
+const mapBackendRiddle = (riddle: any): RiddleType => {
+  return {
+    id: String(riddle.id),
+    riddleId: riddle.id,
+    hint1: riddle.hint_1,
+    hint2: riddle.hint_2,
+    answer: riddle.answer,
+    imageUrl: riddle.image_url,
+    isActive: Boolean(riddle.is_active),
+    createdAt: riddle.created_at,
+  };
+};
+
+const mapToBackendRiddle = (riddle: Partial<RiddleType>) => ({
+  hint_1: riddle.hint1,
+  hint_2: riddle.hint2,
+  answer: riddle.answer,
+  image_url: riddle.imageUrl,
+  is_active: riddle.isActive,
+});
+
+// hint1/hint2 não precisam de mapeamento: o nome do campo já bate com a
+// coluna real no banco (o GORM não insere "_" antes de dígito em "Hint1"/"Hint2").
+const fieldMap: Record<string, string> = {
+  isActive: "is_active",
+};
+
+export const riddlesAPI = {
+  getAll: async (
+    page = 1,
+    limit = 10,
+    sortBy = "id",
+    sortOrder = "asc",
+    searchBy?: string,
+    searchValue?: string
+  ): Promise<RiddlesListResponse> => {
+    const backendSortBy = fieldMap[sortBy] ?? sortBy;
+    const backendSearchBy = searchBy ? (fieldMap[searchBy] ?? searchBy) : undefined;
+
+    let url = `/admin/riddles?page=${page}&limit=${limit}&sort_by=${backendSortBy}&sort_order=${sortOrder}`;
+    if (backendSearchBy && searchValue) {
+      url += `&search_by=${backendSearchBy}&search_value=${searchValue}`;
+    }
+    const response = await client.get<any>(url);
+    return {
+      ...response.data,
+      riddles: response.data.riddles.map(mapBackendRiddle),
+    };
+  },
+
+  getByID: async (id: number): Promise<RiddleType> => {
+    const response = await client.get<any>(`/admin/riddles/${id}`);
+    return mapBackendRiddle(response.data);
+  },
+
+  create: async (data: Omit<RiddleType, "id" | "riddleId" | "createdAt">): Promise<RiddleType> => {
+    const payload = mapToBackendRiddle(data);
+    const response = await client.post<any>("/admin/riddles", payload);
+    return mapBackendRiddle(response.data.riddle);
+  },
+
+  update: async (id: number, data: Partial<RiddleType>): Promise<RiddleType> => {
+    const payload = mapToBackendRiddle(data);
+    const response = await client.put<any>(`/admin/riddles/${id}`, payload);
+    return mapBackendRiddle(response.data.riddle);
+  },
+
+  delete: async (id: number): Promise<{ message: string }> => {
+    const response = await client.delete<{ message: string }>(`/admin/riddles/${id}`);
+    return response.data;
+  },
+
+  uploadCsv: async (file: File): Promise<RiddleType[]> => {
+    const formData = new FormData();
+    formData.append("file", file);
+    const response = await client.post<any>("/admin/riddles/upload-csv", formData, {
+      headers: { "Content-Type": "multipart/form-data" },
+    });
+    return response.data.riddles.map(mapBackendRiddle);
+  },
+};

--- a/new-site/packages/front-backoffice/src/components/CrudTable.tsx
+++ b/new-site/packages/front-backoffice/src/components/CrudTable.tsx
@@ -61,7 +61,8 @@ export interface CrudField {
     | "number"
     | "multivalue"
     | "boolean"
-    | "file";
+    | "file"
+    | "image-preview";
   selectVariants?: Record<string, string>;
   multiValueOptions?: string[];
   readOnly?: boolean;
@@ -70,6 +71,20 @@ export interface CrudField {
   showWhen?: { field: string; value: unknown };
   /** Quando true, o campo é exibido no dialog mas não pode ser editado */
   readonly?: boolean;
+  /** Quando true, o campo não aparece no modal de edição (mas continua
+   *  aparecendo como coluna na tabela). Útil para campos controlados só por
+   *  um controle dedicado na tabela (ex.: `interactiveToggle`). */
+  hideInEdit?: boolean;
+  /** Quando true, o campo não aparece como coluna na tabela (mas continua
+   *  nos modais de criar/editar). Útil para campos só informativos no form,
+   *  como "image-preview". */
+  hideInTable?: boolean;
+  /** Para type "image-preview": nome do campo (via formData) cujo valor é
+   *  usado como URL da imagem a pré-visualizar. Default: o próprio `value`. */
+  previewFrom?: string;
+  /** Para type "boolean": renderiza um Switch clicável na célula da tabela
+   *  (em vez do Badge estático), com efeito imediato via `onToggleField`. */
+  interactiveToggle?: boolean;
 }
 
 export interface CrudQueryParams {
@@ -85,7 +100,8 @@ export interface CrudTableProps {
   data: CrudItemType[];
   fields: CrudField[];
   onEdit: (item: CrudItemType, itemKey: string) => void;
-  onDelete: (id: string) => void;
+  /** Quando omitido, o botão "Excluir" não é exibido nas ações da linha. */
+  onDelete?: (id: string) => void;
   onCreate?: (item: CrudItemType) => void;
   /** When false, hides create/edit/delete buttons */
   canWrite?: boolean;
@@ -103,6 +119,12 @@ export interface CrudTableProps {
   actionIcon?: React.ReactNode;
   /** Tooltip for the action button */
   actionTitle?: string;
+  /** Ícone do botão de editar/visualizar na coluna de ações (default: Pencil) */
+  editIcon?: React.ReactNode;
+  /** Chamado quando um campo boolean com `interactiveToggle` é clicado na
+   *  tabela. O chamador decide se atualiza `data` (ex.: após confirmação e
+   *  chamada à API) — se não atualizar, o Switch permanece como estava. */
+  onToggleField?: (item: CrudItemType, field: string, value: boolean) => void | Promise<void>;
 }
 
 type FormValue = string | string[] | boolean | File | null;
@@ -217,6 +239,38 @@ function FilterControl({
   );
 }
 
+// ─── ImagePreviewBox ───────────────────────────────────────────────────────────
+
+// Pré-visualização ao vivo de uma URL de imagem dentro dos modais de criar/
+// editar (campos type "image-preview"). Sem URL ou com erro de carregamento,
+// cai num placeholder simples.
+function ImagePreviewBox({ url }: { url: string }) {
+  // Guarda qual URL falhou (em vez de um boolean resetado por efeito): assim
+  // que `url` muda para algo novo, `failedUrl` deixa de bater e a imagem nova
+  // é tentada, sem precisar de useEffect+setState.
+  const [failedUrl, setFailedUrl] = useState<string | null>(null);
+
+  const trimmed = url.trim();
+  const failed = trimmed !== "" && failedUrl === trimmed;
+
+  if (!trimmed || failed) {
+    return (
+      <div className="flex h-32 w-full items-center justify-center rounded-lg border border-dashed border-muted/40 bg-muted/10 text-xs text-muted-foreground">
+        {trimmed ? "Não foi possível carregar a imagem" : "Sem imagem"}
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={trimmed}
+      alt="Pré-visualização"
+      onError={() => setFailedUrl(trimmed)}
+      className="h-32 w-full rounded-lg border border-muted/30 bg-muted/10 object-contain"
+    />
+  );
+}
+
 // ─── CrudTable ────────────────────────────────────────────────────────────────
 
 export function CrudTable({
@@ -229,15 +283,22 @@ export function CrudTable({
   onEditClick,
   actionIcon,
   actionTitle,
+  editIcon,
   getItemKey,
   entityLabel = "item",
   defaultPageSize = 10,
   totalRecords,
   onQueryChange,
   canWrite = true,
+  onToggleField,
 }: CrudTableProps) {
   // Fields that make sense as filter targets (files cannot be text-searched)
-  const filterableFields = fields.filter((f) => f.type !== "file");
+  const filterableFields = fields.filter(
+    (f) => f.type !== "file" && f.type !== "image-preview"
+  );
+  // Colunas de fato exibidas na tabela (hideInTable tira campos só-de-form,
+  // como "image-preview", que só fazem sentido dentro do modal).
+  const tableFields = fields.filter((f) => !f.hideInTable);
 
   const [filter, setFilter] = useState("");
   const [filterField, setFilterField] = useState(
@@ -281,8 +342,8 @@ export function CrudTable({
   // Indica se a linha tem célula de texto longo (textarea >120 ou string >40),
   // o que habilita o toggle de expandir/recolher ao clicar na linha.
   const rowHasExpandableContent = (item: CrudItemType): boolean => {
-    return fields.some((field) => {
-      if (field.type === "url") return false; // URL tem truncate próprio
+    return tableFields.some((field) => {
+      if (field.type === "url" || field.type === "image-preview") return false; // URL/preview têm truncate/renderização próprios
       const raw = (item as Record<string, unknown>)[field.value];
       const val = String(raw ?? "");
       if (field.type === "textarea") return val.length > 120;
@@ -409,6 +470,18 @@ export function CrudTable({
 
     if (field.type === "boolean") {
       const bool = Boolean(raw);
+
+      if (field.interactiveToggle && onToggleField) {
+        return (
+          <Switch
+            checked={bool}
+            onCheckedChange={(checked) => onToggleField(item, field.value, checked)}
+            onClick={(e) => e.stopPropagation()}
+            aria-label={`Alternar ${field.label}`}
+          />
+        );
+      }
+
       return (
         <Badge
           className={`text-xs font-medium px-2 py-0.5 ${
@@ -705,7 +778,7 @@ export function CrudTable({
         <Table>
           <TableHeader>
             <TableRow className="border-border bg-muted/30 hover:bg-muted/30">
-              {fields.map((f) => (
+              {tableFields.map((f) => (
                 <TableHead
                   key={f.value}
                   className="cursor-pointer select-none text-muted-foreground text-xs font-semibold uppercase tracking-wider hover:text-primary transition-colors"
@@ -724,7 +797,7 @@ export function CrudTable({
             {data.length === 0 ? (
               <TableRow>
                 <TableCell
-                  colSpan={fields.length + 1}
+                  colSpan={tableFields.length + 1}
                   className="text-center py-12 text-muted-foreground"
                 >
                   <div className="flex flex-col items-center gap-2">
@@ -762,7 +835,7 @@ export function CrudTable({
                           : "bg-muted/10 hover:bg-muted/20"
                     }`}
                   >
-                    {fields.map((f) => (
+                    {tableFields.map((f) => (
                       <TableCell key={f.value} className="py-3">
                         {renderCell(item, f)}
                       </TableCell>
@@ -786,34 +859,34 @@ export function CrudTable({
                           </Button>
                         )}
                         {canWrite && (
-                          <>
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                onEditClick
-                                  ? onEditClick(item, resolveItemKey(item))
-                                  : openEdit(item);
-                              }}
-                              className="h-8 w-8 p-0 text-muted-foreground hover:text-primary hover:bg-primary/10 rounded-lg"
-                              title="Editar"
-                            >
-                              <Pencil className="w-3.5 h-3.5" />
-                            </Button>
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                openDelete(item);
-                              }}
-                              className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded-lg"
-                              title="Excluir"
-                            >
-                              <Trash2 className="w-3.5 h-3.5" />
-                            </Button>
-                          </>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onEditClick
+                                ? onEditClick(item, resolveItemKey(item))
+                                : openEdit(item);
+                            }}
+                            className="h-8 w-8 p-0 text-muted-foreground hover:text-primary hover:bg-primary/10 rounded-lg"
+                            title="Editar"
+                          >
+                            {editIcon ?? <Pencil className="w-3.5 h-3.5" />}
+                          </Button>
+                        )}
+                        {canWrite && onDelete && (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              openDelete(item);
+                            }}
+                            className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded-lg"
+                            title="Excluir"
+                          >
+                            <Trash2 className="w-3.5 h-3.5" />
+                          </Button>
                         )}
                       </div>
                     </TableCell>
@@ -842,7 +915,11 @@ export function CrudTable({
                 >
                   {f.label}
                 </Label>
-                {f.type === "select" && f.selectVariants ? (
+                {f.type === "image-preview" ? (
+                  <ImagePreviewBox
+                    url={(formData[f.previewFrom ?? f.value] as string) ?? ""}
+                  />
+                ) : f.type === "select" && f.selectVariants ? (
                   <Select
                     value={formData[f.value] as string}
                     onValueChange={(v) =>
@@ -1053,7 +1130,7 @@ export function CrudTable({
             </DialogTitle>
           </DialogHeader>
           <div className="space-y-4 py-2">
-            {fields.map((f) => (
+            {fields.filter((f) => !f.hideInEdit).map((f) => (
               <div key={f.value} className="space-y-1.5">
                 <Label className="text-foreground text-sm">{f.label}</Label>
                 {f.readonly ? (
@@ -1072,6 +1149,10 @@ export function CrudTable({
                       {String((selectedItem as Record<string, unknown>)?.[f.value] ?? "—")}
                     </div>
                   )
+                ) : f.type === "image-preview" ? (
+                  <ImagePreviewBox
+                    url={(formData[f.previewFrom ?? f.value] as string) ?? ""}
+                  />
                 ) : f.type === "select" && f.selectVariants ? (
                   <Select
                     value={formData[f.value] as string}
@@ -1289,7 +1370,7 @@ export function CrudTable({
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
               disabled={saving}
               onClick={async () => {
-                if (!selectedItem) return;
+                if (!selectedItem || !onDelete) return;
                 const itemId =
                   selectedItemKey || resolveItemKey(selectedItem);
                 if (!itemId) return;

--- a/new-site/packages/front-backoffice/src/constants/Tabs.tsx
+++ b/new-site/packages/front-backoffice/src/constants/Tabs.tsx
@@ -1,4 +1,4 @@
-import { Calendar, UserCog, User, Key, Hand, ToggleLeft, ShoppingBag, Handshake, DollarSign, FileCheck } from "lucide-react";
+import { Calendar, UserCog, User, Key, Hand, ToggleLeft, ShoppingBag, Handshake, DollarSign, FileCheck, Puzzle } from "lucide-react";
 
 // section deve coincidir com KnownSections em backend/internal/permission/model.go
 export const Tabs: {
@@ -98,6 +98,16 @@ export const Tabs: {
     description: "Gerencie as vendas realizadas para a SEMCOMP.",
     pageNavigate: "/sales",
     icon: <DollarSign className="w-5 h-5" />,
+    bg: "bg-primary/15",
+    hoverBg: "bg-primary/25",
+  },
+  {
+    key: "riddles",
+    section: "Riddles",
+    label: "Riddles",
+    description: "Gerencie os enigmas do jogo de sequência.",
+    pageNavigate: "/riddles",
+    icon: <Puzzle className="w-5 h-5" />,
     bg: "bg-primary/15",
     hoverBg: "bg-primary/25",
   },

--- a/new-site/packages/front-backoffice/src/data/riddlesCrudField.ts
+++ b/new-site/packages/front-backoffice/src/data/riddlesCrudField.ts
@@ -1,0 +1,16 @@
+import { type CrudField } from "@/components/CrudTable";
+
+export const fields: CrudField[] = [
+  { value: "hint1", label: "Título", type: "textarea" },
+  // Pré-visualização ao vivo do link da imagem (campo abaixo). Só existe nos
+  // modais de criar/editar — hideInTable tira da tabela, já que não é um
+  // valor de verdade em si (lê o valor de "imageUrl" via previewFrom).
+  { value: "imagePreview", label: "Pré-visualização", type: "image-preview", previewFrom: "imageUrl", hideInTable: true },
+  { value: "imageUrl", label: "Link da Imagem", type: "text" },
+  { value: "hint2", label: "Subtítulo", type: "textarea" },
+  { value: "answer", label: "Resposta", type: "text" },
+  // Ativar/desativar só pelo switch dedicado na tabela (efeito imediato, ver
+  // Riddles/index.tsx) — readonly tira do form de criação, hideInEdit tira do
+  // modal de edição inteiramente (não aparece nem como somente leitura).
+  { value: "isActive", label: "Ativo", type: "boolean", interactiveToggle: true, readonly: true, hideInEdit: true },
+];

--- a/new-site/packages/front-backoffice/src/pages/Riddles/index.tsx
+++ b/new-site/packages/front-backoffice/src/pages/Riddles/index.tsx
@@ -1,0 +1,210 @@
+import { CrudTable } from "@/components/CrudTable";
+import type { CrudItemType } from "@/types/CrudItem";
+import type { CrudQueryParams } from "@/components/CrudTable";
+import { useCallback, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Tabs } from "@/constants/Tabs";
+import { fields } from "@/data/riddlesCrudField";
+import { BannerCard } from "@/components/BannerCard";
+import { Button } from "@/components/ui/button";
+import { Upload, Eye } from "lucide-react";
+import type { RiddleType } from "@/types/RiddleType";
+import { riddlesAPI } from "@/api/riddles";
+import { useNotification } from "@/contexts/NotificationContext";
+import { useHasPermission } from "@/contexts/AuthContext";
+
+export default function Riddles() {
+  const canWrite = useHasPermission("Riddles", "RW");
+  const navigate = useNavigate();
+  const [data, setData] = useState<RiddleType[]>([]);
+  const [totalRecords, setTotalRecords] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { showNotification } = useNotification();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const lastQueryRef = useRef<CrudQueryParams | undefined>(undefined);
+
+  const fetchRiddles = useCallback(async (params?: CrudQueryParams) => {
+    try {
+      setLoading(true);
+      setError(null);
+      lastQueryRef.current = params;
+
+      const response = await riddlesAPI.getAll(
+        params?.page ?? 1,
+        params?.pageSize ?? 10,
+        params?.sortField ?? "id",
+        params?.sortOrder ?? "asc",
+        params?.filterField && params?.filterValue ? params.filterField : undefined,
+        params?.filterValue || undefined,
+      );
+      setData(response.riddles || []);
+      setTotalRecords(response.filtered_records ?? response.total_records ?? 0);
+    } catch (err) {
+      console.error("Erro ao buscar riddles:", err);
+      setError("Erro ao carregar riddles");
+      setData([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const handleQueryChange = useCallback((params: CrudQueryParams) => {
+    fetchRiddles(params);
+  }, [fetchRiddles]);
+
+  const resolveRiddleKey = (riddle: CrudItemType) => {
+    return String((riddle as RiddleType).riddleId);
+  };
+
+  const handleEdit = async (item: CrudItemType, itemKey: string) => {
+    try {
+      const typedItem = item as RiddleType;
+      const original = data.find((r) => resolveRiddleKey(r) === itemKey);
+      if (!original) return;
+
+      const updated = await riddlesAPI.update(original.riddleId, typedItem);
+
+      setData((prev) =>
+        prev.map((riddle) => (resolveRiddleKey(riddle) === itemKey ? updated : riddle))
+      );
+      showNotification("Riddle editado com sucesso", "success");
+    } catch (err) {
+      console.error("Erro ao editar riddle:", err);
+      setError("Erro ao editar riddle");
+    }
+  };
+
+  // Switch dedicado de "Ativo" na tabela: efeito imediato, com confirmação
+  // (mesmo padrão de window.confirm usado no upload de CSV) só ao desativar
+  // (true -> false). Reativar (false -> true) não precisa de confirmação.
+  // Se o usuário cancelar, `data` não é tocado, então o Switch simplesmente
+  // permanece no estado atual (controlado por `data`), sem chamar a API.
+  const handleToggleActive = async (item: CrudItemType, field: string, checked: boolean) => {
+    if (field !== "isActive") return;
+    const riddle = item as RiddleType;
+
+    if (!checked) {
+      const confirmed = window.confirm(
+        `Tem certeza que deseja desativar o riddle "${riddle.hint1}"? Ele deixará de aparecer para os participantes. Você pode reativá-lo depois.`
+      );
+      if (!confirmed) return;
+    }
+
+    try {
+      const updated = await riddlesAPI.update(riddle.riddleId, { ...riddle, isActive: checked });
+      setData((prev) =>
+        prev.map((r) => (resolveRiddleKey(r) === resolveRiddleKey(riddle) ? updated : r))
+      );
+      showNotification(checked ? "Riddle reativado com sucesso" : "Riddle desativado com sucesso", "success");
+    } catch (err: any) {
+      console.error("Erro ao atualizar riddle:", err);
+      showNotification(err.response?.data?.message || "Erro ao atualizar riddle", "error");
+    }
+  };
+
+  const handleCreate = async (item: CrudItemType) => {
+    try {
+      const typedItem = item as RiddleType;
+      const createdRiddle = await riddlesAPI.create(typedItem);
+      setData((prev) => [...prev, createdRiddle]);
+      setTotalRecords((prev) => prev + 1);
+      showNotification("Riddle criado com sucesso", "success");
+    } catch (err: any) {
+      console.error(err);
+      setError(err.response?.data?.message || "Erro ao criar riddle");
+    }
+  };
+
+  const handleUploadClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileSelected = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+
+    const confirmed = window.confirm(
+      "Importar este CSV vai APAGAR PERMANENTEMENTE todos os riddles atuais e substituí-los pelos do arquivo. Esta ação não pode ser desfeita. Deseja continuar?"
+    );
+    if (!confirmed) return;
+
+    try {
+      setUploading(true);
+      await riddlesAPI.uploadCsv(file);
+      showNotification("Riddles importados com sucesso", "success");
+      await fetchRiddles(lastQueryRef.current);
+    } catch (err: any) {
+      console.error("Erro ao importar CSV:", err);
+      showNotification(err.response?.data?.message || "Erro ao importar CSV", "error");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <section className="mx-auto w-full max-w-7xl px-4 py-8 md:px-6 md:py-10 space-y-6">
+      <BannerCard
+        icon={Tabs.find((tab) => tab.key === "riddles")?.icon}
+        iconClassName="text-violet-400"
+        label="Riddles"
+        title="Gerenciamento de Riddles"
+        description="Cadastre, busque, edite e desative os enigmas do jogo de sequência."
+        onBack={() => navigate("/home")}
+        cardClassName="border-slate-800 bg-linear-to-br from-slate-900 via-slate-900 to-violet-950/30 overflow-hidden relative"
+        labelClassName="text-xs uppercase tracking-[0.3em] text-violet-400 font-medium"
+        titleClassName="text-2xl md:text-3xl text-white font-semibold"
+        descriptionClassName="text-slate-400 mt-1"
+      />
+
+      <div className="rounded-xl border border-border bg-card/80 p-5 space-y-4">
+        {error && (
+          <div className="mb-4 rounded-lg bg-red-900/20 border border-red-700 p-4 text-red-200">
+            {error}
+          </div>
+        )}
+
+        {canWrite && (
+          <div className="flex items-center justify-end">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".csv"
+              hidden
+              onChange={handleFileSelected}
+            />
+            <Button
+              variant="outline"
+              onClick={handleUploadClick}
+              disabled={uploading}
+            >
+              <Upload className="w-4 h-4 mr-2" />
+              {uploading ? "Importando..." : "Importar CSV (substitui tudo)"}
+            </Button>
+          </div>
+        )}
+
+        {loading && data.length === 0 && (
+          <div className="flex items-center justify-center py-12">
+            <p className="text-slate-400">Carregando riddles...</p>
+          </div>
+        )}
+        <CrudTable
+          data={data}
+          fields={fields}
+          onEdit={handleEdit}
+          onCreate={handleCreate}
+          onToggleField={handleToggleActive}
+          editIcon={<Eye className="w-3.5 h-3.5" />}
+          getItemKey={resolveRiddleKey}
+          entityLabel="riddle"
+          totalRecords={totalRecords}
+          onQueryChange={handleQueryChange}
+          canWrite={canWrite}
+        />
+      </div>
+    </section>
+  );
+}

--- a/new-site/packages/front-backoffice/src/routes/Routes.tsx
+++ b/new-site/packages/front-backoffice/src/routes/Routes.tsx
@@ -15,6 +15,7 @@ import PagesAvailability from "@/pages/PagesAvailability";
 import SponsorsCRUD from "@/pages/Sponsors";
 import SalesCRUD from "@/pages/Sales";
 import PapfeDocuments from "@/pages/PapfeDocuments";
+import RiddlesCRUD from "@/pages/Riddles";
 import NotFoundPage from "@/pages/NotFound";
 
 export const router = createBrowserRouter(
@@ -80,6 +81,10 @@ export const router = createBrowserRouter(
             {
               element: <RequirePermission section="PAPFE" />,
               children: [{ path: "/papfe-documents", element: <PapfeDocuments /> }],
+            },
+            {
+              element: <RequirePermission section="Riddles" />,
+              children: [{ path: "/riddles", element: <RiddlesCRUD /> }],
             },
             {
               path: "*",

--- a/new-site/packages/front-backoffice/src/types/RiddleType.ts
+++ b/new-site/packages/front-backoffice/src/types/RiddleType.ts
@@ -1,0 +1,11 @@
+import type { CrudItemType } from "@/types/CrudItem";
+
+export interface RiddleType extends CrudItemType {
+  riddleId: number;
+  hint1: string;
+  hint2: string;
+  answer: string;
+  imageUrl: string;
+  isActive: boolean;
+  createdAt: string;
+}


### PR DESCRIPTION
feat(riddles): implementa backoffice de riddles com CRUD, upload de CSV e toggle

- CRUD de riddles seguindo padrão dos módulos existentes 
- Upload de CSV 
- Inserção manual sempre no fim da fila
- Campo "ativo" editável no CRUD 
- Modal de edição com preview de imagem
- Registro da página no toggle geral de liga/desliga