### PR TITLE
fix: registrar rota /sales/:id/cancel

### DIFF
--- a/new-site/packages/backend/cmd/api/main.go
+++ b/new-site/packages/backend/cmd/api/main.go
@@ -299,6 +299,7 @@ func main() {
 	authRoutes.GET("/sales/:id", pageMW("loja"), salesHandler.GetSaleByID)
 	authRoutes.GET("/sales/:id/status", pageMW("loja"), salesHandler.GetSaleStatus)
 	authRoutes.GET("/sales/:id/events", pageMW("loja"), salesHandler.StreamSaleStatus)
+	authRoutes.PATCH("/sales/:id/cancel", pageMW("loja"), salesHandler.CancelSale)
 
 	// Rota Login Backoffice - Públicas
 	adminRoutes := r.Group("/admin")


### PR DESCRIPTION
## Summary
- O handler `SaleHandler.CancelSale` e o `saleService.CancelSale` já existiam nesta branch, mas a rota nunca foi registrada em `cmd/api/main.go`, deixando o endpoint de cancelamento de pedido (`PATCH /sales/:id/cancel`) inacessível.
- Adiciona `authRoutes.PATCH("/sales/:id/cancel", pageMW("loja"), salesHandler.CancelSale)` junto às demais rotas de vendas do usuário.
- Necessário para o botão "Cancelar compra" do front-site (branch `feat/frontend/cancelar-compra`) funcionar de ponta a ponta.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (falhas em `internal/presence` são pré-existentes nesta branch, não relacionadas a esta mudança)
- [ ] Teste manual: criar pedido PENDENTE e chamar `PATCH /sales/:id/cancel` autenticado

🤖 Generated with [Claude Code](https://claude.com/claude-code)