### PR TITLE
feat: visualização de dados da semcomp no backoffice

### DIFF
--- a/new-site/packages/backend/cmd/api/main.go
+++ b/new-site/packages/backend/cmd/api/main.go
@@ -9,6 +9,7 @@ import (
 	"backend/internal/absenceJustification"
 	"backend/internal/auth"
 	"backend/internal/authBackoffice"
+	"backend/internal/dashboardbackoffice"
 	"backend/internal/database"
 	"backend/internal/event"
 	"backend/internal/log"
@@ -178,6 +179,10 @@ func main() {
 	salesRepo := sales.NewSaleRepository(db)
 	salesService := sales.NewSaleService(salesRepo, productRepo, papfeRepo)
 	salesHandler := sales.NewSaleHandler(salesService)
+
+	dashboardRepo := dashboardbackoffice.NewDashboardRepository(db)
+	dashboardService := dashboardbackoffice.NewDashboardService(dashboardRepo)
+	dashboardHandler := dashboardbackoffice.NewDashboardHandler(dashboardService)
 
 	// Sweeper de expiração: persiste o status EXPIRADO nos PIX pendentes fora da
 	// janela de validade e libera as travas de compra única (consumed_items)
@@ -398,6 +403,9 @@ func main() {
 	admin.GET("/sponsors/:cnpj/packages", permMW("Patrocinadores", permission.PermR), sponsorHandler.GetSponsorPackages)
 	admin.POST("/sponsors/:cnpj/packages", permMW("Patrocinadores", permission.PermRW), sponsorHandler.AddSponsorPackage)
 	admin.DELETE("/sponsors/:cnpj/packages/:year/:package", permMW("Patrocinadores", permission.PermRW), sponsorHandler.RemoveSponsorPackage)
+
+	// Dashboard
+	admin.GET("/dashboard", permMW("Dashboard", permission.PermR), dashboardHandler.GetDashboard)
 
 	r.Run(":4000")
 }

--- a/new-site/packages/backend/internal/dashboardbackoffice/handler.go
+++ b/new-site/packages/backend/internal/dashboardbackoffice/handler.go
@@ -1,0 +1,40 @@
+package dashboardbackoffice
+
+import (
+	"net/http"
+
+	"backend/internal/apierrors"
+
+	"github.com/gin-gonic/gin"
+)
+
+type DashboardHandler struct {
+	service *DashboardService
+}
+
+func NewDashboardHandler(service *DashboardService) *DashboardHandler {
+	return &DashboardHandler{service: service}
+}
+
+// GetDashboard retorna as estatísticas agregadas do dashboard do backoffice.
+// @Summary Retorna dados agregados do dashboard
+// @Tags Dashboard
+// @Produce json
+// @Param sections query []string false "Seções a retornar (users, events, kits, coffees, combos, sales). Se vazio, retorna todas."
+// @Success 200 {object} DashboardResponse
+// @Router /admin/dashboard [get]
+func (h *DashboardHandler) GetDashboard(c *gin.Context) {
+	var query DashboardQuery
+	if err := c.ShouldBindQuery(&query); err != nil {
+		apierrors.HandleAPIError(c, err)
+		return
+	}
+
+	resp, err := h.service.GetDashboard(query)
+	if err != nil {
+		apierrors.HandleAPIError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, resp)
+}

--- a/new-site/packages/backend/internal/dashboardbackoffice/model.go
+++ b/new-site/packages/backend/internal/dashboardbackoffice/model.go
@@ -1,0 +1,173 @@
+package dashboardbackoffice
+
+import "time"
+
+// Usuários - visão geral dos participantes da Semcomp -------------------------
+
+// UsersStats agrega dados gerais dos usuários cadastrados na Semcomp.
+// Populado a partir das tabelas `users`, `absence_justifications` e `presences`.
+type UsersStats struct {
+	Total             int64     `json:"total"`              // total de usuários cadastrados
+	Confirmed         int64     `json:"confirmed"`          // total com e-mail verificado
+	Unconfirmed       int64     `json:"unconfirmed"`        // total com e-mail não verificado
+	JustifiedAbsences int64     `json:"justifiedAbsence"`   // total com falta justificada (aprovada)
+	PendingAbsences   int64     `json:"pendingAbsence"`     // total com justificativa pendente
+	NotJustified      int64     `json:"notJustified"`       // total com justificativa negada
+	MeanRate          float64   `json:"meanRate"`            // média de presença (excluindo justificados)
+	TotalWithPapfe    int64     `json:"totalWithPapfe"`      // total de usuários com PAPFE
+	LastUpdate        time.Time `json:"lastUpdate"`
+}
+
+// Eventos - inscrições e presenças por evento --------------------------------
+
+// EventStats agrega dados de um evento específico (minicurso, palestra, etc.).
+// Populado a partir das tabelas `events`, `signin_events` e `presences`.
+type EventStats struct {
+	EventName  string    `json:"eventName"`
+	EventType  string    `json:"eventType"`
+	EventDate  time.Time `json:"eventDate"`
+	Total      int64     `json:"total"`      // total de inscritos
+	Present    int64     `json:"present"`     // presenças registradas
+	Absent     int64     `json:"absent"`      // inscritos que não compareceram
+	MeanRate   float64   `json:"meanRate"`    // taxa de presença (present/total)
+	WaitListed int64     `json:"waitListed"`  // total na lista de espera
+	LastUpdate time.Time `json:"lastUpdate"`
+}
+
+// EventsSummary é o resumo agregado de todos os eventos da Semcomp.
+type EventsSummary struct {
+	TotalEvents       int64        `json:"totalEvents"`
+	TotalSignins      int64        `json:"totalSignins"`
+	TotalPresences    int64        `json:"totalPresences"`
+	OverallAttendance float64      `json:"overallAttendance"`
+	EventsByType      []LabelCount `json:"eventsByType"`
+	Events            []EventStats `json:"events"`
+	LastUpdate        time.Time    `json:"lastUpdate"`
+}
+
+// Vendas de Kits - amostragem por cor, tamanho e corte ---------------------------
+
+// KitSalesStats agrega dados de vendas de camisetas/kits.
+// Populado cruzando `sales` (status PAGO) -> `sale_items` -> `products` (type KIT) -> `kits`.
+type KitSalesStats struct {
+	TotalSold      int64            `json:"totalSold"`
+	TotalPending   int64            `json:"totalPending"`
+	TotalPickedUp  int64            `json:"totalPickedUp"`
+	TotalRevenue   float64          `json:"totalRevenue"`   // receita total
+	ByColor        []LabelCount     `json:"byColor"`
+	BySize         []LabelCount     `json:"bySize"`
+	ByCut          []LabelCount     `json:"byCut"`          // babylook ou tradicional
+	ByColorAndSize []KitVariantStat `json:"byColorAndSize"`
+	LastUpdate     time.Time        `json:"lastUpdate"`
+}
+
+// KitVariantStat detalha vendas de uma combinação cor × tamanho × corte.
+type KitVariantStat struct {
+	Color      string `json:"color"`
+	Size       string `json:"size"`
+	IsBabylook bool   `json:"isBabylook"`
+	Count      int64  `json:"count"`
+}
+
+// Vendas de Coffes - amostragem por tipo/nome -----------------------------------
+
+// CoffeeSalesStats agrega dados de vendas de coffees.
+// Populado cruzando `sales` (status PAGO) -> `sale_items` -> `products` (type COFFEE) -> `coffees`.
+type CoffeeSalesStats struct {
+	TotalSold    int64        `json:"totalSold"`
+	TotalPending int64        `json:"totalPending"`
+	TotalRevenue float64      `json:"totalRevenue"` 
+	ByCoffee     []CoffeeStat `json:"byCoffee"`     // detalha por tipo de coffe
+	LastUpdate   time.Time    `json:"lastUpdate"`
+}
+
+// CoffeeStat detalha vendas de um tipo específico de coffee.
+type CoffeeStat struct {
+	CoffeeID   uint      `json:"coffeeId"`
+	CoffeeName string    `json:"coffeeName"`
+	DateTime   time.Time `json:"dateTime"`   // data/hora do coffee
+	Sold       int64     `json:"sold"`       // quantidade vendida (PAGO)
+	Pending    int64     `json:"pending"`    // quantidade em pedidos pendentes
+	Revenue    float64   `json:"revenue"`    // receita do coffee específico
+}
+
+// SalesOverviewStats é o resumo geral de vendas de todos os tipos de produto.
+// Populado a partir de `sales` e `sale_items`.
+type SalesOverviewStats struct {
+	TotalSales       int64              `json:"totalSales"`       // total de pedidos criados
+	TotalPaid        int64              `json:"totalPaid"`        // pedidos com status PAGO
+	TotalPending     int64              `json:"totalPending"`     // pedidos com status PENDENTE
+	TotalCanceled    int64              `json:"totalCanceled"`    // pedidos cancelados/rejeitados/reembolsados
+	TotalExpired     int64              `json:"totalExpired"`     // pedidos expirados
+	TotalRevenue     float64            `json:"totalRevenue"`     // receita total (soma de PAGO)
+	RevenueByProduct []LabelValue       `json:"revenueByProduct"` // receita por tipo de produto (KIT, COFFEE, COMBO)
+	SalesByStatus    []LabelCount       `json:"salesByStatus"`    // contagem de vendas por status
+	SalesByMethod    []LabelCount       `json:"salesByMethod"`    // contagem por método de pagamento
+	RevenueTimeline  []TimeSeriesPoint  `json:"revenueTimeline"`  // evolução da receita ao longo do tempo
+	LastUpdate       time.Time          `json:"lastUpdate"`
+}
+
+// Vendas de combos - visão geral de vendas de combos -------------------------------
+
+// ComboSalesStats agrega dados de vendas de combos.
+type ComboSalesStats struct {
+	TotalSold    int64       `json:"totalSold"`
+	TotalPending int64       `json:"totalPending"`
+	TotalRevenue float64     `json:"totalRevenue"`
+	ByCombo      []ComboStat `json:"byCombo"`
+	LastUpdate   time.Time   `json:"lastUpdate"`
+}
+
+// ComboStat detalha vendas de um combo específico.
+type ComboStat struct {
+	ComboID   uint    `json:"comboId"`
+	ComboName string  `json:"comboName"`
+	Sold      int64   `json:"sold"`
+	Pending   int64   `json:"pending"`
+	Revenue   float64 `json:"revenue"`
+}
+
+// Tipos auxiliares ----------------------------------------------------------
+
+// LabelCount é um par label -> contagem (ex: "Azul" -> 42).
+type LabelCount struct {
+	Label string `json:"label"`
+	Count int64  `json:"count"`
+}
+
+// LabelValue é um par label → valor numérico (ex: "KIT" → 1500.00).
+type LabelValue struct {
+	Label string  `json:"label"`
+	Value float64 `json:"value"`
+}
+
+// RangeCount agrupa contagens por faixa numérica.
+type RangeCount struct {
+	Min   int   `json:"min"`
+	Max   int   `json:"max"`
+	Count int64 `json:"count"`
+}
+
+// TimeSeriesPoint representa um ponto em série temporal (ex: receita diária).
+type TimeSeriesPoint struct {
+	Date  time.Time `json:"date"`
+	Value float64   `json:"value"`
+}
+
+// Resposta completa do dashboard --------------------------------------------
+
+// DashboardResponse agrega todas as seções de análise.
+type DashboardResponse struct {
+	Users   *UsersStats        `json:"users,omitempty"`
+	Events  *EventsSummary     `json:"events,omitempty"`
+	Kits    *KitSalesStats     `json:"kits,omitempty"`
+	Coffees *CoffeeSalesStats  `json:"coffees,omitempty"`
+	Combos  *ComboSalesStats   `json:"combos,omitempty"`
+	Sales   *SalesOverviewStats `json:"sales,omitempty"`
+}
+
+// DashboardQuery controla quais seções do dashboard devem ser retornadas.
+// Se nenhuma seção for especificada, retorna todas.
+type DashboardQuery struct {
+	Sections []string `form:"sections"` // ex: ?sections=users,kits,coffees,events,sales,combos
+}

--- a/new-site/packages/backend/internal/dashboardbackoffice/model.go
+++ b/new-site/packages/backend/internal/dashboardbackoffice/model.go
@@ -40,8 +40,8 @@ type EventsSummary struct {
 	TotalSignins      int64        `json:"totalSignins"`
 	TotalPresences    int64        `json:"totalPresences"`
 	OverallAttendance float64      `json:"overallAttendance"`
-	EventsByType      []LabelCount `json:"eventsByType"`
-	Events            []EventStats `json:"events"`
+	EventsByType      []LabelCount `gorm:"-" json:"eventsByType"`
+	Events            []EventStats `gorm:"-" json:"events"`
 	LastUpdate        time.Time    `json:"lastUpdate"`
 }
 
@@ -54,10 +54,10 @@ type KitSalesStats struct {
 	TotalPending   int64            `json:"totalPending"`
 	TotalPickedUp  int64            `json:"totalPickedUp"`
 	TotalRevenue   float64          `json:"totalRevenue"`   // receita total
-	ByColor        []LabelCount     `json:"byColor"`
-	BySize         []LabelCount     `json:"bySize"`
-	ByCut          []LabelCount     `json:"byCut"`          // babylook ou tradicional
-	ByColorAndSize []KitVariantStat `json:"byColorAndSize"`
+	ByColor        []LabelCount     `gorm:"-" json:"byColor"`
+	BySize         []LabelCount     `gorm:"-" json:"bySize"`
+	ByCut          []LabelCount     `gorm:"-" json:"byCut"`          // babylook ou tradicional
+	ByColorAndSize []KitVariantStat `gorm:"-" json:"byColorAndSize"`
 	LastUpdate     time.Time        `json:"lastUpdate"`
 }
 
@@ -77,7 +77,7 @@ type CoffeeSalesStats struct {
 	TotalSold    int64        `json:"totalSold"`
 	TotalPending int64        `json:"totalPending"`
 	TotalRevenue float64      `json:"totalRevenue"` 
-	ByCoffee     []CoffeeStat `json:"byCoffee"`     // detalha por tipo de coffe
+	ByCoffee     []CoffeeStat `gorm:"-" json:"byCoffee"`     // detalha por tipo de coffe
 	LastUpdate   time.Time    `json:"lastUpdate"`
 }
 
@@ -100,11 +100,11 @@ type SalesOverviewStats struct {
 	TotalCanceled    int64              `json:"totalCanceled"`    // pedidos cancelados/rejeitados/reembolsados
 	TotalExpired     int64              `json:"totalExpired"`     // pedidos expirados
 	TotalRevenue     float64            `json:"totalRevenue"`     // receita total (soma de PAGO)
-	RevenueByProduct []LabelValue       `json:"revenueByProduct"` // receita por tipo de produto (KIT, COFFEE, COMBO)
-	SalesByStatus    []LabelCount       `json:"salesByStatus"`    // contagem de vendas por status
-	SalesByMethod    []LabelCount       `json:"salesByMethod"`    // contagem por método de pagamento
-	RevenueTimeline  []TimeSeriesPoint  `json:"revenueTimeline"`  // evolução da receita ao longo do tempo
-	TopProducts      []ProductRank      `json:"topProducts"`      // ranking por produto (mais vendidos / maior faturamento)
+	RevenueByProduct []LabelValue       `gorm:"-" json:"revenueByProduct"` // receita por tipo de produto (KIT, COFFEE, COMBO)
+	SalesByStatus    []LabelCount       `gorm:"-" json:"salesByStatus"`    // contagem de vendas por status
+	SalesByMethod    []LabelCount       `gorm:"-" json:"salesByMethod"`    // contagem por método de pagamento
+	RevenueTimeline  []TimeSeriesPoint  `gorm:"-" json:"revenueTimeline"`  // evolução da receita ao longo do tempo
+	TopProducts      []ProductRank      `gorm:"-" json:"topProducts"`      // ranking por produto (mais vendidos / maior faturamento)
 	LastUpdate       time.Time          `json:"lastUpdate"`
 }
 
@@ -124,7 +124,7 @@ type ComboSalesStats struct {
 	TotalSold    int64       `json:"totalSold"`
 	TotalPending int64       `json:"totalPending"`
 	TotalRevenue float64     `json:"totalRevenue"`
-	ByCombo      []ComboStat `json:"byCombo"`
+	ByCombo      []ComboStat `gorm:"-" json:"byCombo"`
 	LastUpdate   time.Time   `json:"lastUpdate"`
 }
 

--- a/new-site/packages/backend/internal/dashboardbackoffice/model.go
+++ b/new-site/packages/backend/internal/dashboardbackoffice/model.go
@@ -13,8 +13,8 @@ type UsersStats struct {
 	JustifiedAbsences int64     `json:"justifiedAbsence"`   // total com falta justificada (aprovada)
 	PendingAbsences   int64     `json:"pendingAbsence"`     // total com justificativa pendente
 	NotJustified      int64     `json:"notJustified"`       // total com justificativa negada
-	MeanRate          float64   `json:"meanRate"`            // média de presença (excluindo justificados)
-	TotalWithPapfe    int64     `json:"totalWithPapfe"`      // total de usuários com PAPFE
+	MeanRate          float64   `json:"meanRate"`           // média de presença (excluindo justificados)
+	TotalWithPapfe    int64     `json:"totalWithPapfe"`     // total de usuários com PAPFE
 	LastUpdate        time.Time `json:"lastUpdate"`
 }
 
@@ -26,7 +26,7 @@ type EventStats struct {
 	EventName  string    `json:"eventName"`
 	EventType  string    `json:"eventType"`
 	EventDate  time.Time `json:"eventDate"`
-	Total      int64     `json:"total"`      // total de inscritos
+	Total      int64     `json:"total"`       // total de inscritos
 	Present    int64     `json:"present"`     // presenças registradas
 	Absent     int64     `json:"absent"`      // inscritos que não compareceram
 	MeanRate   float64   `json:"meanRate"`    // taxa de presença (present/total)
@@ -61,7 +61,7 @@ type KitSalesStats struct {
 	LastUpdate     time.Time        `json:"lastUpdate"`
 }
 
-// KitVariantStat detalha vendas de uma combinação cor × tamanho × corte.
+// KitVariantStat detalha vendas de uma combinação cor x tamanho x corte.
 type KitVariantStat struct {
 	Color      string `json:"color"`
 	Size       string `json:"size"`
@@ -135,7 +135,7 @@ type LabelCount struct {
 	Count int64  `json:"count"`
 }
 
-// LabelValue é um par label → valor numérico (ex: "KIT" → 1500.00).
+// LabelValue é um par label -> valor numérico (ex: "KIT" → 1500.00).
 type LabelValue struct {
 	Label string  `json:"label"`
 	Value float64 `json:"value"`

--- a/new-site/packages/backend/internal/dashboardbackoffice/model.go
+++ b/new-site/packages/backend/internal/dashboardbackoffice/model.go
@@ -104,7 +104,17 @@ type SalesOverviewStats struct {
 	SalesByStatus    []LabelCount       `json:"salesByStatus"`    // contagem de vendas por status
 	SalesByMethod    []LabelCount       `json:"salesByMethod"`    // contagem por método de pagamento
 	RevenueTimeline  []TimeSeriesPoint  `json:"revenueTimeline"`  // evolução da receita ao longo do tempo
+	TopProducts      []ProductRank      `json:"topProducts"`      // ranking por produto (mais vendidos / maior faturamento)
 	LastUpdate       time.Time          `json:"lastUpdate"`
+}
+
+// ProductRank agrega vendas de um produto específico (apenas pedidos PAGO).
+type ProductRank struct {
+	ProductID uint    `json:"productId"`
+	Name      string  `json:"name"`
+	Type      string  `json:"type"`
+	Sold      int64   `json:"sold"`    // quantidade vendida
+	Revenue   float64 `json:"revenue"` // faturamento (soma de unit_price * quantity)
 }
 
 // Vendas de combos - visão geral de vendas de combos -------------------------------

--- a/new-site/packages/backend/internal/dashboardbackoffice/model.go
+++ b/new-site/packages/backend/internal/dashboardbackoffice/model.go
@@ -15,6 +15,8 @@ type UsersStats struct {
 	NotJustified      int64     `json:"notJustified"`       // total com justificativa negada
 	MeanRate          float64   `json:"meanRate"`           // média de presença (excluindo justificados)
 	TotalWithPapfe    int64     `json:"totalWithPapfe"`     // total de usuários com PAPFE
+	USPParticipants   int64     `json:"uspParticipants"`    // participantes com e-mail @usp.br
+	ExternalParticipants int64  `json:"externalParticipants"` // participantes externos (e-mail fora de @usp.br)
 	LastUpdate        time.Time `json:"lastUpdate"`
 }
 

--- a/new-site/packages/backend/internal/dashboardbackoffice/repository.go
+++ b/new-site/packages/backend/internal/dashboardbackoffice/repository.go
@@ -20,10 +20,18 @@ func NewDashboardRepository(db *gorm.DB) *DashboardRepository {
 // Usuários -------------------------------------------------------------------
 
 func (r *DashboardRepository) GetUsersStats() (*UsersStats, error) {
-	now := time.Now()
-	stats := &UsersStats{LastUpdate: now}
+	stats := &UsersStats{}
 
 	// Total de usuários e confirmados
+	// Cada agregação é escaneada em um alvo descartável: o GORM zera o
+	// destino de cada Scan, então escanear direto em *stats apagaria os
+	// valores das consultas anteriores.
+	var totals struct {
+		Total          int64
+		Confirmed      int64
+		Unconfirmed    int64
+		TotalWithPapfe int64
+	}
 	if err := r.db.Raw(`
 		SELECT
 			COUNT(*)                                       AS total,
@@ -31,31 +39,49 @@ func (r *DashboardRepository) GetUsersStats() (*UsersStats, error) {
 			COUNT(*) FILTER (WHERE email_verified = false) AS unconfirmed,
 			COUNT(*) FILTER (WHERE has_papfe = true)       AS total_with_papfe
 		FROM users
-	`).Scan(stats).Error; err != nil {
+	`).Scan(&totals).Error; err != nil {
 		return nil, err
 	}
+	stats.Total = totals.Total
+	stats.Confirmed = totals.Confirmed
+	stats.Unconfirmed = totals.Unconfirmed
+	stats.TotalWithPapfe = totals.TotalWithPapfe
 
 	// Justificativas de ausência
+	var justifications struct {
+		JustifiedAbsences int64
+		PendingAbsences   int64
+		NotJustified      int64
+	}
 	if err := r.db.Raw(`
 		SELECT
 			COUNT(*) FILTER (WHERE status = 'aprovado')    AS justified_absences,
 			COUNT(*) FILTER (WHERE status = 'em_analise')  AS pending_absences,
 			COUNT(*) FILTER (WHERE status = 'negado')      AS not_justified
 		FROM absence_justifications
-	`).Scan(stats).Error; err != nil {
+	`).Scan(&justifications).Error; err != nil {
 		return nil, err
 	}
+	stats.JustifiedAbsences = justifications.JustifiedAbsences
+	stats.PendingAbsences = justifications.PendingAbsences
+	stats.NotJustified = justifications.NotJustified
 
 	// Média de presença (excluindo usuários com justificativa aprovada)
+	var rate struct {
+		MeanRate float64
+	}
 	if err := r.db.Raw(`
 		SELECT COALESCE(AVG(u.presence_rate), 0) AS mean_rate
 		FROM users u
 		WHERE u.email NOT IN (
 			SELECT aj.user_email FROM absence_justifications aj WHERE aj.status = 'aprovado'
 		)
-	`).Scan(stats).Error; err != nil {
+	`).Scan(&rate).Error; err != nil {
 		return nil, err
 	}
+	stats.MeanRate = rate.MeanRate
+
+	stats.LastUpdate = time.Now()
 
 	return stats, nil
 }
@@ -230,6 +256,8 @@ func (r *DashboardRepository) GetKitSalesStats() (*KitSalesStats, error) {
 	}
 	stats.ByColorAndSize = byVariant
 
+	stats.LastUpdate = now
+
 	return stats, nil
 }
 
@@ -274,6 +302,8 @@ func (r *DashboardRepository) GetCoffeeSalesStats() (*CoffeeSalesStats, error) {
 		return nil, err
 	}
 	stats.ByCoffee = byCoffee
+
+	stats.LastUpdate = now
 
 	return stats, nil
 }
@@ -350,6 +380,8 @@ func (r *DashboardRepository) GetSalesOverview() (*SalesOverviewStats, error) {
 	}
 	stats.RevenueTimeline = timeline
 
+	stats.LastUpdate = now
+
 	return stats, nil
 }
 
@@ -420,6 +452,8 @@ func (r *DashboardRepository) GetComboSalesStats() (*ComboSalesStats, error) {
 		return nil, err
 	}
 	stats.ByCombo = byCombo
+
+	stats.LastUpdate = now
 
 	return stats, nil
 }

--- a/new-site/packages/backend/internal/dashboardbackoffice/repository.go
+++ b/new-site/packages/backend/internal/dashboardbackoffice/repository.go
@@ -1,0 +1,397 @@
+package dashboardbackoffice
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// DashboardRepository encapsula todas as queries de agregação para o dashboard.
+// As queries fazem JOINs e GROUP BYs diretamente nas tabelas existentes - não
+// há tabela própria deste módulo.
+type DashboardRepository struct {
+	db *gorm.DB
+}
+
+func NewDashboardRepository(db *gorm.DB) *DashboardRepository {
+	return &DashboardRepository{db: db}
+}
+
+// Usuários -------------------------------------------------------------------
+
+func (r *DashboardRepository) GetUsersStats() (*UsersStats, error) {
+	now := time.Now()
+	stats := &UsersStats{LastUpdate: now}
+
+	// Total de usuários e confirmados
+	if err := r.db.Raw(`
+		SELECT
+			COUNT(*)                                       AS total,
+			COUNT(*) FILTER (WHERE email_verified = true)  AS confirmed,
+			COUNT(*) FILTER (WHERE email_verified = false) AS unconfirmed,
+			COUNT(*) FILTER (WHERE has_papfe = true)       AS total_with_papfe
+		FROM users
+	`).Scan(stats).Error; err != nil {
+		return nil, err
+	}
+
+	// Justificativas de ausência
+	if err := r.db.Raw(`
+		SELECT
+			COUNT(*) FILTER (WHERE status = 'aprovado')    AS justified_absences,
+			COUNT(*) FILTER (WHERE status = 'em_analise')  AS pending_absences,
+			COUNT(*) FILTER (WHERE status = 'negado')      AS not_justified
+		FROM absence_justifications
+	`).Scan(stats).Error; err != nil {
+		return nil, err
+	}
+
+	// Média de presença (excluindo usuários com justificativa aprovada)
+	if err := r.db.Raw(`
+		SELECT COALESCE(AVG(u.presence_rate), 0) AS mean_rate
+		FROM users u
+		WHERE u.email NOT IN (
+			SELECT aj.user_email FROM absence_justifications aj WHERE aj.status = 'aprovado'
+		)
+	`).Scan(stats).Error; err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}
+
+// Eventos --------------------------------------------------------------------
+
+func (r *DashboardRepository) GetEventsStats() (*EventsSummary, error) {
+	now := time.Now()
+	summary := &EventsSummary{LastUpdate: now}
+
+	// Total de eventos
+	if err := r.db.Raw(`SELECT COUNT(*) FROM events`).Scan(&summary.TotalEvents).Error; err != nil {
+		return nil, err
+	}
+
+	// Total de inscrições
+	if err := r.db.Raw(`SELECT COUNT(*) FROM signin_events`).Scan(&summary.TotalSignins).Error; err != nil {
+		return nil, err
+	}
+
+	// Total de presenças
+	if err := r.db.Raw(`SELECT COUNT(*) FROM presences`).Scan(&summary.TotalPresences).Error; err != nil {
+		return nil, err
+	}
+
+	// Taxa de presença geral
+	if summary.TotalSignins > 0 {
+		summary.OverallAttendance = float64(summary.TotalPresences) / float64(summary.TotalSignins)
+	}
+
+	// Contagem de eventos por tipo
+	var eventsByType []LabelCount
+	if err := r.db.Raw(`
+		SELECT type AS label, COUNT(*) AS count
+		FROM events
+		WHERE type IS NOT NULL AND type != ''
+		GROUP BY type
+		ORDER BY count DESC
+	`).Scan(&eventsByType).Error; err != nil {
+		return nil, err
+	}
+	summary.EventsByType = eventsByType
+
+	// Detalhamento por evento
+	var events []EventStats
+	if err := r.db.Raw(`
+		SELECT
+			e.name                                                                 AS event_name,
+			e.type                                                                 AS event_type,
+			e.init_date                                                            AS event_date,
+			COALESCE(s.total, 0)                                                   AS total,
+			COALESCE(p.present, 0)                                                 AS present,
+			COALESCE(s.total, 0) - COALESCE(p.present, 0)                          AS absent,
+			CASE WHEN COALESCE(s.total, 0) > 0
+				THEN COALESCE(p.present, 0)::float / s.total
+				ELSE 0
+			END                                                                    AS mean_rate,
+			COALESCE(s.wait_listed, 0)                                             AS wait_listed
+		FROM events e
+		LEFT JOIN (
+			SELECT event_name, event_init_date,
+				COUNT(*)                                                      AS total,
+				COUNT(*) FILTER (WHERE status = 'Lista de Espera')            AS wait_listed
+			FROM signin_events
+			GROUP BY event_name, event_init_date
+		) s ON s.event_name = e.name AND s.event_init_date = e.init_date
+		LEFT JOIN (
+			SELECT event_name, event_init_date, COUNT(*) AS present
+			FROM presences
+			GROUP BY event_name, event_init_date
+		) p ON p.event_name = e.name AND p.event_init_date = e.init_date
+		ORDER BY e.init_date
+	`).Scan(&events).Error; err != nil {
+		return nil, err
+	}
+
+	// Atribui LastUpdate a cada evento
+	for i := range events {
+		events[i].LastUpdate = now
+	}
+	summary.Events = events
+
+	return summary, nil
+}
+
+// Kits -------------------------------------------------------------------
+
+func (r *DashboardRepository) GetKitSalesStats() (*KitSalesStats, error) {
+	now := time.Now()
+	stats := &KitSalesStats{LastUpdate: now}
+
+	// Totais gerais de kits vendidos/pendentes/retirados e receita
+	// Considera sale_items que apontam diretamente para um KIT OU
+	// sale_items que apontam para um COMBO com kit_product_id preenchido.
+	if err := r.db.Raw(`
+		SELECT
+			COALESCE(SUM(si.quantity) FILTER (WHERE s.status = 'PAGO'), 0)                       AS total_sold,
+			COALESCE(SUM(si.quantity) FILTER (WHERE s.status = 'PENDENTE'), 0)                   AS total_pending,
+			COUNT(*) FILTER (WHERE si.is_picked_up = true AND s.status = 'PAGO')                 AS total_picked_up,
+			COALESCE(SUM(si.unit_price * si.quantity) FILTER (WHERE s.status = 'PAGO'), 0)       AS total_revenue
+		FROM sale_items si
+		JOIN sales s ON s.id = si.sale_id
+		JOIN products p ON p.id = si.product_id
+		WHERE p.type = 'KIT'
+	`).Scan(stats).Error; err != nil {
+		return nil, err
+	}
+
+	// Distribuição por cor (vendas pagas)
+	var byColor []LabelCount
+	if err := r.db.Raw(`
+		SELECT k.color AS label, COALESCE(SUM(si.quantity), 0) AS count
+		FROM sale_items si
+		JOIN sales s ON s.id = si.sale_id
+		JOIN products p ON p.id = si.product_id
+		JOIN kits k ON k.id = p.id
+		WHERE p.type = 'KIT' AND s.status = 'PAGO'
+		GROUP BY k.color
+		ORDER BY count DESC
+	`).Scan(&byColor).Error; err != nil {
+		return nil, err
+	}
+	stats.ByColor = byColor
+
+	// Distribuição por tamanho
+	var bySize []LabelCount
+	if err := r.db.Raw(`
+		SELECT k.size AS label, COALESCE(SUM(si.quantity), 0) AS count
+		FROM sale_items si
+		JOIN sales s ON s.id = si.sale_id
+		JOIN products p ON p.id = si.product_id
+		JOIN kits k ON k.id = p.id
+		WHERE p.type = 'KIT' AND s.status = 'PAGO'
+		GROUP BY k.size
+		ORDER BY count DESC
+	`).Scan(&bySize).Error; err != nil {
+		return nil, err
+	}
+	stats.BySize = bySize
+
+	// Distribuição por corte (babylook vs. tradicional)
+	var byCut []LabelCount
+	if err := r.db.Raw(`
+		SELECT
+			CASE WHEN k.is_babylook THEN 'Babylook' ELSE 'Tradicional' END AS label,
+			COALESCE(SUM(si.quantity), 0) AS count
+		FROM sale_items si
+		JOIN sales s ON s.id = si.sale_id
+		JOIN products p ON p.id = si.product_id
+		JOIN kits k ON k.id = p.id
+		WHERE p.type = 'KIT' AND s.status = 'PAGO'
+		GROUP BY k.is_babylook
+		ORDER BY count DESC
+	`).Scan(&byCut).Error; err != nil {
+		return nil, err
+	}
+	stats.ByCut = byCut
+
+	// Cruzamento cor × tamanho × corte
+	var byVariant []KitVariantStat
+	if err := r.db.Raw(`
+		SELECT k.color, k.size, k.is_babylook, COALESCE(SUM(si.quantity), 0) AS count
+		FROM sale_items si
+		JOIN sales s ON s.id = si.sale_id
+		JOIN products p ON p.id = si.product_id
+		JOIN kits k ON k.id = p.id
+		WHERE p.type = 'KIT' AND s.status = 'PAGO'
+		GROUP BY k.color, k.size, k.is_babylook
+		ORDER BY count DESC
+	`).Scan(&byVariant).Error; err != nil {
+		return nil, err
+	}
+	stats.ByColorAndSize = byVariant
+
+	return stats, nil
+}
+
+// Coffes -------------------------------------------------------------------
+
+func (r *DashboardRepository) GetCoffeeSalesStats() (*CoffeeSalesStats, error) {
+	now := time.Now()
+	stats := &CoffeeSalesStats{LastUpdate: now}
+
+	// Totais gerais
+	if err := r.db.Raw(`
+		SELECT
+			COALESCE(SUM(si.quantity) FILTER (WHERE s.status = 'PAGO'), 0)                   AS total_sold,
+			COALESCE(SUM(si.quantity) FILTER (WHERE s.status = 'PENDENTE'), 0)               AS total_pending,
+			COALESCE(SUM(si.unit_price * si.quantity) FILTER (WHERE s.status = 'PAGO'), 0)   AS total_revenue
+		FROM sale_items si
+		JOIN sales s ON s.id = si.sale_id
+		JOIN products p ON p.id = si.product_id
+		WHERE p.type = 'COFFEE'
+	`).Scan(stats).Error; err != nil {
+		return nil, err
+	}
+
+	// Detalhamento por coffee
+	var byCoffee []CoffeeStat
+	if err := r.db.Raw(`
+		SELECT
+			p.id                                                                             AS coffee_id,
+			c.name                                                                           AS coffee_name,
+			c.date_time                                                                      AS date_time,
+			COALESCE(SUM(si.quantity) FILTER (WHERE s.status = 'PAGO'), 0)                   AS sold,
+			COALESCE(SUM(si.quantity) FILTER (WHERE s.status = 'PENDENTE'), 0)               AS pending,
+			COALESCE(SUM(si.unit_price * si.quantity) FILTER (WHERE s.status = 'PAGO'), 0)   AS revenue
+		FROM products p
+		JOIN coffees c ON c.id = p.id
+		LEFT JOIN sale_items si ON si.product_id = p.id
+		LEFT JOIN sales s ON s.id = si.sale_id
+		WHERE p.type = 'COFFEE'
+		GROUP BY p.id, c.name, c.date_time
+		ORDER BY c.date_time
+	`).Scan(&byCoffee).Error; err != nil {
+		return nil, err
+	}
+	stats.ByCoffee = byCoffee
+
+	return stats, nil
+}
+
+// Vendas Gerais --------------------------------------------------------------
+
+func (r *DashboardRepository) GetSalesOverview() (*SalesOverviewStats, error) {
+	now := time.Now()
+	stats := &SalesOverviewStats{LastUpdate: now}
+
+	// Contagem geral por status
+	if err := r.db.Raw(`
+		SELECT
+			COUNT(*)                                             AS total_sales,
+			COUNT(*) FILTER (WHERE status = 'PAGO')              AS total_paid,
+			COUNT(*) FILTER (WHERE status = 'PENDENTE')          AS total_pending,
+			COUNT(*) FILTER (WHERE status IN ('CANCELADO','REJEITADO','REEMBOLSADO')) AS total_canceled,
+			COUNT(*) FILTER (WHERE status = 'EXPIRADO')          AS total_expired,
+			COALESCE(SUM(total_amount) FILTER (WHERE status = 'PAGO'), 0) AS total_revenue
+		FROM sales
+	`).Scan(stats).Error; err != nil {
+		return nil, err
+	}
+
+	// Receita por tipo de produto
+	var revenueByProduct []LabelValue
+	if err := r.db.Raw(`
+		SELECT p.type AS label, COALESCE(SUM(si.unit_price * si.quantity), 0) AS value
+		FROM sale_items si
+		JOIN sales s ON s.id = si.sale_id
+		JOIN products p ON p.id = si.product_id
+		WHERE s.status = 'PAGO'
+		GROUP BY p.type
+		ORDER BY value DESC
+	`).Scan(&revenueByProduct).Error; err != nil {
+		return nil, err
+	}
+	stats.RevenueByProduct = revenueByProduct
+
+	// Vendas por status
+	var salesByStatus []LabelCount
+	if err := r.db.Raw(`
+		SELECT status AS label, COUNT(*) AS count
+		FROM sales
+		GROUP BY status
+		ORDER BY count DESC
+	`).Scan(&salesByStatus).Error; err != nil {
+		return nil, err
+	}
+	stats.SalesByStatus = salesByStatus
+
+	// Vendas por método de pagamento
+	var salesByMethod []LabelCount
+	if err := r.db.Raw(`
+		SELECT payment_method AS label, COUNT(*) AS count
+		FROM sales
+		GROUP BY payment_method
+		ORDER BY count DESC
+	`).Scan(&salesByMethod).Error; err != nil {
+		return nil, err
+	}
+	stats.SalesByMethod = salesByMethod
+
+	// Evolução de receita ao longo do tempo (agrupada por dia, apenas vendas pagas)
+	var timeline []TimeSeriesPoint
+	if err := r.db.Raw(`
+		SELECT DATE(updated_at) AS date, SUM(total_amount) AS value
+		FROM sales
+		WHERE status = 'PAGO'
+		GROUP BY DATE(updated_at)
+		ORDER BY date
+	`).Scan(&timeline).Error; err != nil {
+		return nil, err
+	}
+	stats.RevenueTimeline = timeline
+
+	return stats, nil
+}
+
+// Combos -------------------------------------------------------------------
+
+func (r *DashboardRepository) GetComboSalesStats() (*ComboSalesStats, error) {
+	now := time.Now()
+	stats := &ComboSalesStats{LastUpdate: now}
+
+	// Totais gerais
+	if err := r.db.Raw(`
+		SELECT
+			COALESCE(SUM(si.quantity) FILTER (WHERE s.status = 'PAGO'), 0)                   AS total_sold,
+			COALESCE(SUM(si.quantity) FILTER (WHERE s.status = 'PENDENTE'), 0)               AS total_pending,
+			COALESCE(SUM(si.unit_price * si.quantity) FILTER (WHERE s.status = 'PAGO'), 0)   AS total_revenue
+		FROM sale_items si
+		JOIN sales s ON s.id = si.sale_id
+		JOIN products p ON p.id = si.product_id
+		WHERE p.type = 'COMBO'
+	`).Scan(stats).Error; err != nil {
+		return nil, err
+	}
+
+	// Detalhamento por combo
+	var byCombo []ComboStat
+	if err := r.db.Raw(`
+		SELECT
+			p.id                                                                             AS combo_id,
+			p.name                                                                           AS combo_name,
+			COALESCE(SUM(si.quantity) FILTER (WHERE s.status = 'PAGO'), 0)                   AS sold,
+			COALESCE(SUM(si.quantity) FILTER (WHERE s.status = 'PENDENTE'), 0)               AS pending,
+			COALESCE(SUM(si.unit_price * si.quantity) FILTER (WHERE s.status = 'PAGO'), 0)   AS revenue
+		FROM products p
+		LEFT JOIN sale_items si ON si.product_id = p.id
+		LEFT JOIN sales s ON s.id = si.sale_id
+		WHERE p.type = 'COMBO'
+		GROUP BY p.id, p.name
+		ORDER BY sold DESC
+	`).Scan(&byCombo).Error; err != nil {
+		return nil, err
+	}
+	stats.ByCombo = byCombo
+
+	return stats, nil
+}

--- a/new-site/packages/backend/internal/dashboardbackoffice/repository.go
+++ b/new-site/packages/backend/internal/dashboardbackoffice/repository.go
@@ -353,6 +353,34 @@ func (r *DashboardRepository) GetSalesOverview() (*SalesOverviewStats, error) {
 	return stats, nil
 }
 
+// Ranking por produto (apenas vendas PAGO) ----------------------------------
+
+// GetTopProducts retorna o ranking de produtos por quantidade vendida e
+// faturamento. O nome exibido prioriza o nome do produto; quando vazio, usa o
+// nome do kit/coffee relacionado; em último caso, o próprio tipo.
+func (r *DashboardRepository) GetTopProducts() ([]ProductRank, error) {
+	var products []ProductRank
+	if err := r.db.Raw(`
+		SELECT
+			p.id AS product_id,
+			COALESCE(NULLIF(p.name, ''), k.name, c.name, p.type) AS name,
+			p.type AS type,
+			SUM(si.quantity)                  AS sold,
+			SUM(si.unit_price * si.quantity)  AS revenue
+		FROM sale_items si
+		JOIN sales s ON s.id = si.sale_id
+		JOIN products p ON p.id = si.product_id
+		LEFT JOIN kits k ON k.id = p.id
+		LEFT JOIN coffees c ON c.id = p.id
+		WHERE s.status = 'PAGO'
+		GROUP BY p.id, p.name, p.type, k.name, c.name
+		ORDER BY sold DESC
+	`).Scan(&products).Error; err != nil {
+		return nil, err
+	}
+	return products, nil
+}
+
 // Combos -------------------------------------------------------------------
 
 func (r *DashboardRepository) GetComboSalesStats() (*ComboSalesStats, error) {

--- a/new-site/packages/backend/internal/dashboardbackoffice/repository.go
+++ b/new-site/packages/backend/internal/dashboardbackoffice/repository.go
@@ -81,6 +81,26 @@ func (r *DashboardRepository) GetUsersStats() (*UsersStats, error) {
 	}
 	stats.MeanRate = rate.MeanRate
 
+	// Participantes USP x externos (baseado no domínio do e-mail)
+	// Válido apontar: essa estimativa não é totalmente confiável 
+	// pelo fato de que alunos USP também podem ter usado email externo 
+	// para o cadastro. Aqui supomos o caso ideal em que todo aluno da USP 
+	// usou o email USP
+	var origin struct {
+		USPParticipants      int64
+		ExternalParticipants int64
+	}
+	if err := r.db.Raw(`
+		SELECT
+			COUNT(*) FILTER (WHERE LOWER(email) LIKE '%@usp.br')         AS usp_participants,
+			COUNT(*) FILTER (WHERE LOWER(email) NOT LIKE '%@usp.br')     AS external_participants
+		FROM users
+	`).Scan(&origin).Error; err != nil {
+		return nil, err
+	}
+	stats.USPParticipants = origin.USPParticipants
+	stats.ExternalParticipants = origin.ExternalParticipants
+
 	stats.LastUpdate = time.Now()
 
 	return stats, nil
@@ -173,32 +193,58 @@ func (r *DashboardRepository) GetKitSalesStats() (*KitSalesStats, error) {
 	now := time.Now()
 	stats := &KitSalesStats{LastUpdate: now}
 
-	// Totais gerais de kits vendidos/pendentes/retirados e receita
-	// Considera sale_items que apontam diretamente para um KIT OU
-	// sale_items que apontam para um COMBO com kit_product_id preenchido.
+	// Totais gerais de kits vendidos/pendentes/retirados e receita.
+	// Inclui tanto sale_items que apontam diretamente para um KIT quanto
+	// sale_items de COMBO que possuem kit_product_id preenchido.
 	if err := r.db.Raw(`
+		WITH kit_items AS (
+			-- Kits comprados avulsos
+			SELECT si.quantity, si.unit_price, si.is_picked_up, s.status,
+			       si.product_id AS kit_id
+			FROM sale_items si
+			JOIN sales s ON s.id = si.sale_id
+			JOIN products p ON p.id = si.product_id
+			WHERE p.type = 'KIT'
+
+			UNION ALL
+
+			-- Kits comprados dentro de um combo (via kit_product_id)
+			SELECT si.quantity, si.unit_price, si.is_picked_up, s.status,
+			       si.kit_product_id AS kit_id
+			FROM sale_items si
+			JOIN sales s ON s.id = si.sale_id
+			JOIN products p ON p.id = si.product_id
+			WHERE p.type = 'COMBO' AND si.kit_product_id IS NOT NULL
+		)
 		SELECT
-			COALESCE(SUM(si.quantity) FILTER (WHERE s.status = 'PAGO'), 0)                       AS total_sold,
-			COALESCE(SUM(si.quantity) FILTER (WHERE s.status = 'PENDENTE'), 0)                   AS total_pending,
-			COUNT(*) FILTER (WHERE si.is_picked_up = true AND s.status = 'PAGO')                 AS total_picked_up,
-			COALESCE(SUM(si.unit_price * si.quantity) FILTER (WHERE s.status = 'PAGO'), 0)       AS total_revenue
-		FROM sale_items si
-		JOIN sales s ON s.id = si.sale_id
-		JOIN products p ON p.id = si.product_id
-		WHERE p.type = 'KIT'
+			COALESCE(SUM(quantity) FILTER (WHERE status = 'PAGO'), 0)                       AS total_sold,
+			COALESCE(SUM(quantity) FILTER (WHERE status = 'PENDENTE'), 0)                   AS total_pending,
+			COUNT(*) FILTER (WHERE is_picked_up = true AND status = 'PAGO')                 AS total_picked_up,
+			COALESCE(SUM(unit_price * quantity) FILTER (WHERE status = 'PAGO'), 0)           AS total_revenue
+		FROM kit_items
 	`).Scan(stats).Error; err != nil {
 		return nil, err
 	}
 
-	// Distribuição por cor (vendas pagas)
+	// Distribuição por cor (vendas pagas, incluindo kits de combos)
 	var byColor []LabelCount
 	if err := r.db.Raw(`
-		SELECT k.color AS label, COALESCE(SUM(si.quantity), 0) AS count
-		FROM sale_items si
-		JOIN sales s ON s.id = si.sale_id
-		JOIN products p ON p.id = si.product_id
-		JOIN kits k ON k.id = p.id
-		WHERE p.type = 'KIT' AND s.status = 'PAGO'
+		WITH kit_items AS (
+			SELECT si.quantity, si.product_id AS kit_id
+			FROM sale_items si
+			JOIN sales s ON s.id = si.sale_id
+			JOIN products p ON p.id = si.product_id
+			WHERE p.type = 'KIT' AND s.status = 'PAGO'
+			UNION ALL
+			SELECT si.quantity, si.kit_product_id AS kit_id
+			FROM sale_items si
+			JOIN sales s ON s.id = si.sale_id
+			JOIN products p ON p.id = si.product_id
+			WHERE p.type = 'COMBO' AND si.kit_product_id IS NOT NULL AND s.status = 'PAGO'
+		)
+		SELECT k.color AS label, COALESCE(SUM(ki.quantity), 0) AS count
+		FROM kit_items ki
+		JOIN kits k ON k.id = ki.kit_id
 		GROUP BY k.color
 		ORDER BY count DESC
 	`).Scan(&byColor).Error; err != nil {
@@ -206,15 +252,25 @@ func (r *DashboardRepository) GetKitSalesStats() (*KitSalesStats, error) {
 	}
 	stats.ByColor = byColor
 
-	// Distribuição por tamanho
+	// Distribuição por tamanho (incluindo kits de combos)
 	var bySize []LabelCount
 	if err := r.db.Raw(`
-		SELECT k.size AS label, COALESCE(SUM(si.quantity), 0) AS count
-		FROM sale_items si
-		JOIN sales s ON s.id = si.sale_id
-		JOIN products p ON p.id = si.product_id
-		JOIN kits k ON k.id = p.id
-		WHERE p.type = 'KIT' AND s.status = 'PAGO'
+		WITH kit_items AS (
+			SELECT si.quantity, si.product_id AS kit_id
+			FROM sale_items si
+			JOIN sales s ON s.id = si.sale_id
+			JOIN products p ON p.id = si.product_id
+			WHERE p.type = 'KIT' AND s.status = 'PAGO'
+			UNION ALL
+			SELECT si.quantity, si.kit_product_id AS kit_id
+			FROM sale_items si
+			JOIN sales s ON s.id = si.sale_id
+			JOIN products p ON p.id = si.product_id
+			WHERE p.type = 'COMBO' AND si.kit_product_id IS NOT NULL AND s.status = 'PAGO'
+		)
+		SELECT k.size AS label, COALESCE(SUM(ki.quantity), 0) AS count
+		FROM kit_items ki
+		JOIN kits k ON k.id = ki.kit_id
 		GROUP BY k.size
 		ORDER BY count DESC
 	`).Scan(&bySize).Error; err != nil {
@@ -222,17 +278,27 @@ func (r *DashboardRepository) GetKitSalesStats() (*KitSalesStats, error) {
 	}
 	stats.BySize = bySize
 
-	// Distribuição por corte (babylook vs. tradicional)
+	// Distribuição por corte (babylook vs. tradicional, incluindo kits de combos)
 	var byCut []LabelCount
 	if err := r.db.Raw(`
+		WITH kit_items AS (
+			SELECT si.quantity, si.product_id AS kit_id
+			FROM sale_items si
+			JOIN sales s ON s.id = si.sale_id
+			JOIN products p ON p.id = si.product_id
+			WHERE p.type = 'KIT' AND s.status = 'PAGO'
+			UNION ALL
+			SELECT si.quantity, si.kit_product_id AS kit_id
+			FROM sale_items si
+			JOIN sales s ON s.id = si.sale_id
+			JOIN products p ON p.id = si.product_id
+			WHERE p.type = 'COMBO' AND si.kit_product_id IS NOT NULL AND s.status = 'PAGO'
+		)
 		SELECT
 			CASE WHEN k.is_babylook THEN 'Babylook' ELSE 'Tradicional' END AS label,
-			COALESCE(SUM(si.quantity), 0) AS count
-		FROM sale_items si
-		JOIN sales s ON s.id = si.sale_id
-		JOIN products p ON p.id = si.product_id
-		JOIN kits k ON k.id = p.id
-		WHERE p.type = 'KIT' AND s.status = 'PAGO'
+			COALESCE(SUM(ki.quantity), 0) AS count
+		FROM kit_items ki
+		JOIN kits k ON k.id = ki.kit_id
 		GROUP BY k.is_babylook
 		ORDER BY count DESC
 	`).Scan(&byCut).Error; err != nil {
@@ -240,15 +306,25 @@ func (r *DashboardRepository) GetKitSalesStats() (*KitSalesStats, error) {
 	}
 	stats.ByCut = byCut
 
-	// Cruzamento cor × tamanho × corte
+	// Cruzamento cor × tamanho × corte (incluindo kits de combos)
 	var byVariant []KitVariantStat
 	if err := r.db.Raw(`
-		SELECT k.color, k.size, k.is_babylook, COALESCE(SUM(si.quantity), 0) AS count
-		FROM sale_items si
-		JOIN sales s ON s.id = si.sale_id
-		JOIN products p ON p.id = si.product_id
-		JOIN kits k ON k.id = p.id
-		WHERE p.type = 'KIT' AND s.status = 'PAGO'
+		WITH kit_items AS (
+			SELECT si.quantity, si.product_id AS kit_id
+			FROM sale_items si
+			JOIN sales s ON s.id = si.sale_id
+			JOIN products p ON p.id = si.product_id
+			WHERE p.type = 'KIT' AND s.status = 'PAGO'
+			UNION ALL
+			SELECT si.quantity, si.kit_product_id AS kit_id
+			FROM sale_items si
+			JOIN sales s ON s.id = si.sale_id
+			JOIN products p ON p.id = si.product_id
+			WHERE p.type = 'COMBO' AND si.kit_product_id IS NOT NULL AND s.status = 'PAGO'
+		)
+		SELECT k.color, k.size, k.is_babylook, COALESCE(SUM(ki.quantity), 0) AS count
+		FROM kit_items ki
+		JOIN kits k ON k.id = ki.kit_id
 		GROUP BY k.color, k.size, k.is_babylook
 		ORDER BY count DESC
 	`).Scan(&byVariant).Error; err != nil {
@@ -267,34 +343,68 @@ func (r *DashboardRepository) GetCoffeeSalesStats() (*CoffeeSalesStats, error) {
 	now := time.Now()
 	stats := &CoffeeSalesStats{LastUpdate: now}
 
-	// Totais gerais
+	// Totais gerais (incluindo coffees vendidos dentro de combos)
 	if err := r.db.Raw(`
+		WITH coffee_sales AS (
+			-- Coffees comprados avulsos
+			SELECT si.quantity, si.unit_price, s.status
+			FROM sale_items si
+			JOIN sales s ON s.id = si.sale_id
+			JOIN products p ON p.id = si.product_id
+			WHERE p.type = 'COFFEE'
+
+			UNION ALL
+
+			-- Coffees comprados dentro de um combo (via combo_items)
+			SELECT si.quantity * ci.quantity AS quantity, si.unit_price, s.status
+			FROM sale_items si
+			JOIN sales s ON s.id = si.sale_id
+			JOIN products p ON p.id = si.product_id
+			JOIN combo_items ci ON ci.combo_id = p.id
+			JOIN products pi ON pi.id = ci.item_id
+			WHERE p.type = 'COMBO' AND pi.type = 'COFFEE'
+		)
 		SELECT
-			COALESCE(SUM(si.quantity) FILTER (WHERE s.status = 'PAGO'), 0)                   AS total_sold,
-			COALESCE(SUM(si.quantity) FILTER (WHERE s.status = 'PENDENTE'), 0)               AS total_pending,
-			COALESCE(SUM(si.unit_price * si.quantity) FILTER (WHERE s.status = 'PAGO'), 0)   AS total_revenue
-		FROM sale_items si
-		JOIN sales s ON s.id = si.sale_id
-		JOIN products p ON p.id = si.product_id
-		WHERE p.type = 'COFFEE'
+			COALESCE(SUM(quantity) FILTER (WHERE status = 'PAGO'), 0)                   AS total_sold,
+			COALESCE(SUM(quantity) FILTER (WHERE status = 'PENDENTE'), 0)               AS total_pending,
+			COALESCE(SUM(unit_price * quantity) FILTER (WHERE status = 'PAGO'), 0)      AS total_revenue
+		FROM coffee_sales
 	`).Scan(stats).Error; err != nil {
 		return nil, err
 	}
 
-	// Detalhamento por coffee
+	// Detalhamento por coffee (incluindo vendas via combo)
 	var byCoffee []CoffeeStat
 	if err := r.db.Raw(`
+		WITH coffee_sales AS (
+			-- Coffees comprados avulsos
+			SELECT si.product_id AS coffee_id, si.quantity, si.unit_price, s.status
+			FROM sale_items si
+			JOIN sales s ON s.id = si.sale_id
+			JOIN products p ON p.id = si.product_id
+			WHERE p.type = 'COFFEE'
+
+			UNION ALL
+
+			-- Coffees comprados dentro de um combo
+			SELECT ci.item_id AS coffee_id, si.quantity * ci.quantity AS quantity, si.unit_price, s.status
+			FROM sale_items si
+			JOIN sales s ON s.id = si.sale_id
+			JOIN products p ON p.id = si.product_id
+			JOIN combo_items ci ON ci.combo_id = p.id
+			JOIN products pi ON pi.id = ci.item_id
+			WHERE p.type = 'COMBO' AND pi.type = 'COFFEE'
+		)
 		SELECT
 			p.id                                                                             AS coffee_id,
 			c.name                                                                           AS coffee_name,
 			c.date_time                                                                      AS date_time,
-			COALESCE(SUM(si.quantity) FILTER (WHERE s.status = 'PAGO'), 0)                   AS sold,
-			COALESCE(SUM(si.quantity) FILTER (WHERE s.status = 'PENDENTE'), 0)               AS pending,
-			COALESCE(SUM(si.unit_price * si.quantity) FILTER (WHERE s.status = 'PAGO'), 0)   AS revenue
+			COALESCE(SUM(cs.quantity) FILTER (WHERE cs.status = 'PAGO'), 0)                  AS sold,
+			COALESCE(SUM(cs.quantity) FILTER (WHERE cs.status = 'PENDENTE'), 0)               AS pending,
+			COALESCE(SUM(cs.unit_price * cs.quantity) FILTER (WHERE cs.status = 'PAGO'), 0)  AS revenue
 		FROM products p
 		JOIN coffees c ON c.id = p.id
-		LEFT JOIN sale_items si ON si.product_id = p.id
-		LEFT JOIN sales s ON s.id = si.sale_id
+		LEFT JOIN coffee_sales cs ON cs.coffee_id = p.id
 		WHERE p.type = 'COFFEE'
 		GROUP BY p.id, c.name, c.date_time
 		ORDER BY c.date_time

--- a/new-site/packages/backend/internal/dashboardbackoffice/service.go
+++ b/new-site/packages/backend/internal/dashboardbackoffice/service.go
@@ -1,0 +1,86 @@
+package dashboardbackoffice
+
+import (
+	"strings"
+
+	"backend/internal/apierrors"
+)
+
+type DashboardService struct {
+	repo *DashboardRepository
+}
+
+func NewDashboardService(repo *DashboardRepository) *DashboardService {
+	return &DashboardService{repo: repo}
+}
+
+// GetDashboard monta a resposta agregada do dashboard. Quando nenhuma seção é
+// especificada em DashboardQuery.Sections, todas as seções são retornadas.
+func (s *DashboardService) GetDashboard(query DashboardQuery) (*DashboardResponse, error) {
+	requested := query.Sections
+	all := len(requested) == 0
+
+	want := func(section string) bool {
+		if all {
+			return true
+		}
+		for _, s := range requested {
+			if strings.TrimSpace(s) == section {
+				return true
+			}
+		}
+		return false
+	}
+
+	resp := &DashboardResponse{}
+
+	if want("users") {
+		users, err := s.repo.GetUsersStats()
+		if err != nil {
+			return nil, apierrors.InternalServerError("Erro ao calcular estatísticas de usuários", err)
+		}
+		resp.Users = users
+	}
+
+	if want("events") {
+		events, err := s.repo.GetEventsStats()
+		if err != nil {
+			return nil, apierrors.InternalServerError("Erro ao calcular estatísticas de eventos", err)
+		}
+		resp.Events = events
+	}
+
+	if want("kits") {
+		kits, err := s.repo.GetKitSalesStats()
+		if err != nil {
+			return nil, apierrors.InternalServerError("Erro ao calcular estatísticas de vendas de kits", err)
+		}
+		resp.Kits = kits
+	}
+
+	if want("coffees") {
+		coffees, err := s.repo.GetCoffeeSalesStats()
+		if err != nil {
+			return nil, apierrors.InternalServerError("Erro ao calcular estatísticas de vendas de coffes", err)
+		}
+		resp.Coffees = coffees
+	}
+
+	if want("combos") {
+		combos, err := s.repo.GetComboSalesStats()
+		if err != nil {
+			return nil, apierrors.InternalServerError("Erro ao calcular estatísticas de vendas de combos", err)
+		}
+		resp.Combos = combos
+	}
+
+	if want("sales") {
+		sales, err := s.repo.GetSalesOverview()
+		if err != nil {
+			return nil, apierrors.InternalServerError("Erro ao calcular panorama de vendas", err)
+		}
+		resp.Sales = sales
+	}
+
+	return resp, nil
+}

--- a/new-site/packages/backend/internal/dashboardbackoffice/service.go
+++ b/new-site/packages/backend/internal/dashboardbackoffice/service.go
@@ -79,6 +79,13 @@ func (s *DashboardService) GetDashboard(query DashboardQuery) (*DashboardRespons
 		if err != nil {
 			return nil, apierrors.InternalServerError("Erro ao calcular panorama de vendas", err)
 		}
+
+		topProducts, err := s.repo.GetTopProducts()
+		if err != nil {
+			return nil, apierrors.InternalServerError("Erro ao calcular ranking de produtos", err)
+		}
+		sales.TopProducts = topProducts
+
 		resp.Sales = sales
 	}
 

--- a/new-site/packages/backend/internal/permission/model.go
+++ b/new-site/packages/backend/internal/permission/model.go
@@ -38,6 +38,7 @@ var KnownSections = []string{
 	"Avisos",
 	"Justificativas de Ausência",
 	"Inscrições",
+	"Dashboard",
 }
 
 type Permission struct {

--- a/new-site/packages/front-backoffice/package-lock.json
+++ b/new-site/packages/front-backoffice/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "^19.2.4",
         "react-icons": "^5.6.0",
         "react-router-dom": "^7.13.2",
+        "recharts": "^3.10.1",
         "shadcn": "^3.8.3",
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7",
@@ -2790,6 +2791,32 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
@@ -3071,6 +3098,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/forms": {
       "version": "0.5.11",
@@ -3428,6 +3467,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-kVd74ta9eof3eJOvbNd1vGKS/XERRyQbT26Og63hIsvDO84cjD5gEOhsXf26w3FSoNlPVz84DOFcKv/oou+fMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -3490,6 +3592,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
@@ -4516,6 +4624,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -4541,6 +4770,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -4802,6 +5037,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.52.0.tgz",
+      "integrity": "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types",
+        "tests/browser-compat"
+      ]
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -5035,6 +5282,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -5872,6 +6125,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "11.1.18",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.18.tgz",
+      "integrity": "sha512-EQyQtLiYW029lyoczMl/Hh4Xu7cDecSc58JRYpHyL4tIAu3eqd1yJzQX04d2BZHDkzFFvm6qJEJWOtfDSWAXbQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -5903,6 +6166,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
@@ -7549,6 +7821,36 @@
         "react": "*"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
@@ -7672,6 +7974,51 @@
         "node": ">= 4"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.10.1.tgz",
+      "integrity": "sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^11.1.8",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7689,6 +8036,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -8706,6 +9059,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/new-site/packages/front-backoffice/package.json
+++ b/new-site/packages/front-backoffice/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^19.2.4",
     "react-icons": "^5.6.0",
     "react-router-dom": "^7.13.2",
+    "recharts": "^3.10.1",
     "shadcn": "^3.8.3",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",

--- a/new-site/packages/front-backoffice/src/api/dashboard.ts
+++ b/new-site/packages/front-backoffice/src/api/dashboard.ts
@@ -1,0 +1,161 @@
+import client from "./client";
+
+// ============================================================
+// Tipos (espelham internal/dashboardbackoffice/model.go)
+// ============================================================
+
+export interface LabelCount {
+  label: string;
+  count: number;
+}
+
+export interface LabelValue {
+  label: string;
+  value: number;
+}
+
+export interface TimeSeriesPoint {
+  date: string;
+  value: number;
+}
+
+// Usuários - visão geral dos participantes
+export interface UsersStats {
+  total: number;
+  confirmed: number;
+  unconfirmed: number;
+  justifiedAbsence: number;
+  pendingAbsence: number;
+  notJustified: number;
+  meanRate: number;
+  totalWithPapfe: number;
+  lastUpdate: string;
+}
+
+// Eventos - inscrições e presenças por evento
+export interface EventStats {
+  eventName: string;
+  eventType: string;
+  eventDate: string;
+  total: number;
+  present: number;
+  absent: number;
+  meanRate: number;
+  waitListed: number;
+  lastUpdate: string;
+}
+
+export interface EventsSummary {
+  totalEvents: number;
+  totalSignins: number;
+  totalPresences: number;
+  overallAttendance: number;
+  eventsByType?: LabelCount[];
+  events?: EventStats[];
+  lastUpdate: string;
+}
+
+// Vendas de kits - amostragem por cor, tamanho e corte
+export interface KitVariantStat {
+  color: string;
+  size: string;
+  isBabylook: boolean;
+  count: number;
+}
+
+export interface KitSalesStats {
+  totalSold: number;
+  totalPending: number;
+  totalPickedUp: number;
+  totalRevenue: number;
+  byColor?: LabelCount[];
+  bySize?: LabelCount[];
+  byCut?: LabelCount[];
+  byColorAndSize?: KitVariantStat[];
+  lastUpdate: string;
+}
+
+// Vendas de coffes
+export interface CoffeeStat {
+  coffeeId: number;
+  coffeeName: string;
+  dateTime: string;
+  sold: number;
+  pending: number;
+  revenue: number;
+}
+
+export interface CoffeeSalesStats {
+  totalSold: number;
+  totalPending: number;
+  totalRevenue: number;
+  byCoffee?: CoffeeStat[];
+  lastUpdate: string;
+}
+
+// Vendas de combos
+export interface ComboStat {
+  comboId: number;
+  comboName: string;
+  sold: number;
+  pending: number;
+  revenue: number;
+}
+
+export interface ComboSalesStats {
+  totalSold: number;
+  totalPending: number;
+  totalRevenue: number;
+  byCombo?: ComboStat[];
+  lastUpdate: string;
+}
+
+// Panorama geral de vendas
+export interface ProductRank {
+  productId: number;
+  name: string;
+  type: string;
+  sold: number;
+  revenue: number;
+}
+
+export interface SalesOverviewStats {
+  totalSales: number;
+  totalPaid: number;
+  totalPending: number;
+  totalCanceled: number;
+  totalExpired: number;
+  totalRevenue: number;
+  revenueByProduct?: LabelValue[];
+  salesByStatus?: LabelCount[];
+  salesByMethod?: LabelCount[];
+  revenueTimeline?: TimeSeriesPoint[];
+  topProducts?: ProductRank[];
+  lastUpdate: string;
+}
+
+// Resposta completa do dashboard
+export interface DashboardResponse {
+  users?: UsersStats;
+  events?: EventsSummary;
+  kits?: KitSalesStats;
+  coffees?: CoffeeSalesStats;
+  combos?: ComboSalesStats;
+  sales?: SalesOverviewStats;
+}
+
+export interface GetDashboardParams {
+  // Seções a retornar (users, events, kits, coffees, combos, sales).
+  // Se vazio, o backend retorna todas.
+  sections?: string[];
+}
+
+export const dashboardAPI = {
+  // GET /admin/dashboard — estatísticas agregadas do backoffice
+  get: async (params?: GetDashboardParams): Promise<DashboardResponse> => {
+    const response = await client.get<DashboardResponse>("/admin/dashboard", {
+      params,
+    });
+    return response.data;
+  },
+};

--- a/new-site/packages/front-backoffice/src/api/dashboard.ts
+++ b/new-site/packages/front-backoffice/src/api/dashboard.ts
@@ -29,6 +29,8 @@ export interface UsersStats {
   notJustified: number;
   meanRate: number;
   totalWithPapfe: number;
+  uspParticipants: number;
+  externalParticipants: number;
   lastUpdate: string;
 }
 

--- a/new-site/packages/front-backoffice/src/api/index.ts
+++ b/new-site/packages/front-backoffice/src/api/index.ts
@@ -15,5 +15,6 @@ export { pagesAPI } from "./pages";
 export { sponsorsAPI } from "./sponsors";
 export { absenceJustificationsAPI } from "./absenceJustifications";
 export { salesAPI } from "./sales";
+export { dashboardAPI } from "./dashboard";
 export { default as client } from "./client";
 export type { LoginResponse, RegisterResponse, ProfileResponse, ApiError } from "@/types/APIResponseType";

--- a/new-site/packages/front-backoffice/src/constants/Tabs.tsx
+++ b/new-site/packages/front-backoffice/src/constants/Tabs.tsx
@@ -1,4 +1,4 @@
-import { Calendar, UserCog, User, Key, Hand, ToggleLeft, ShoppingBag, Handshake, DollarSign, FileCheck, FileWarning } from "lucide-react";
+import { Calendar, UserCog, User, Key, Hand, ToggleLeft, ShoppingBag, Handshake, DollarSign, FileCheck, FileWarning, BarChart3 } from "lucide-react";
 
 // section deve coincidir com KnownSections em backend/internal/permission/model.go
 export const Tabs: {
@@ -129,6 +129,16 @@ export const Tabs: {
     description: "Revise e aprove justificativas de ausência dos participantes.",
     pageNavigate: "/absence-justifications",
     icon: <FileWarning className="w-5 h-5" />,
+    bg: "bg-primary/15",
+    hoverBg: "bg-primary/25",
+  },
+  {
+    key: "dashboard",
+    section: "Dashboard",
+    label: "Dados",
+    description: "Visualize métricas e dados da Semcomp.",
+    pageNavigate: "/dashboard",
+    icon: <BarChart3 className="w-5 h-5" />,
     bg: "bg-primary/15",
     hoverBg: "bg-primary/25",
   },

--- a/new-site/packages/front-backoffice/src/pages/Dashboard/components/CoffeesCard.tsx
+++ b/new-site/packages/front-backoffice/src/pages/Dashboard/components/CoffeesCard.tsx
@@ -1,0 +1,41 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Coffee } from "lucide-react";
+import type { CoffeeSalesStats } from "@/api/dashboard";
+
+export default function CoffeesCard({
+  data,
+  loading,
+}: {
+  data?: CoffeeSalesStats;
+  loading: boolean;
+}) {
+  return (
+    <Card className="border-border bg-card/80 rounded-2xl transition-colors hover:border-primary/40">
+      <CardHeader>
+        <div className="mb-1 flex items-center gap-2">
+          <span className="rounded-lg bg-primary/15 p-2 text-primary">
+            <Coffee className="w-5 h-5" />
+          </span>
+          <CardTitle>Coffes vendidos</CardTitle>
+        </div>
+        <CardDescription>Quantidade total de coffes vendidos.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <p className="text-sm text-muted-foreground">Carregando...</p>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center py-6">
+            <p className="text-4xl md:text-5xl font-bold text-primary">
+              {(data?.totalSold ?? 0).toLocaleString("pt-BR")}
+            </p>
+            <p className="mt-2 text-xs uppercase tracking-wide text-muted-foreground">
+              Coffes vendidos
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/new-site/packages/front-backoffice/src/pages/Dashboard/components/CoffeesCard.tsx
+++ b/new-site/packages/front-backoffice/src/pages/Dashboard/components/CoffeesCard.tsx
@@ -1,6 +1,17 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Coffee } from "lucide-react";
 import type { CoffeeSalesStats } from "@/api/dashboard";
+import { isNightCoffee } from "@/utils/coffeeRules";
+
+function formatDateTime(dateTime: string): string {
+  return new Date(dateTime).toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
 
 export default function CoffeesCard({
   data,
@@ -9,6 +20,8 @@ export default function CoffeesCard({
   data?: CoffeeSalesStats;
   loading: boolean;
 }) {
+  const coffees = data?.byCoffee ?? [];
+
   return (
     <Card className="border-border bg-card/80 rounded-2xl transition-colors hover:border-primary/40">
       <CardHeader>
@@ -26,13 +39,52 @@ export default function CoffeesCard({
             <p className="text-sm text-muted-foreground">Carregando...</p>
           </div>
         ) : (
-          <div className="flex flex-col items-center justify-center py-6">
-            <p className="text-4xl md:text-5xl font-bold text-primary">
-              {(data?.totalSold ?? 0).toLocaleString("pt-BR")}
-            </p>
-            <p className="mt-2 text-xs uppercase tracking-wide text-muted-foreground">
-              Coffes vendidos
-            </p>
+          <div className="space-y-4">
+            <div className="flex flex-col items-center justify-center py-6">
+              <p className="text-4xl md:text-5xl font-bold text-primary">
+                {(data?.totalSold ?? 0).toLocaleString("pt-BR")}
+              </p>
+              <p className="mt-2 text-xs uppercase tracking-wide text-muted-foreground">
+                Coffes vendidos
+              </p>
+            </div>
+
+            <div className="space-y-3">
+              <p className="text-sm font-semibold text-foreground">Por dia</p>
+              {coffees.length === 0 ? (
+                <p className="py-4 text-center text-sm text-muted-foreground">Sem dados de coffes vendidos.</p>
+              ) : (
+                <div className="space-y-2 max-h-44 overflow-y-auto pr-1">
+                  {coffees.map((coffee) => (
+                    <div
+                      key={coffee.coffeeId}
+                      className="flex items-center justify-between gap-2 rounded-xl border border-border/50 bg-muted/20 p-3"
+                    >
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium text-foreground">
+                          {formatDateTime(coffee.dateTime)}
+                        </p>
+                        <span
+                          className={`mt-1 inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                            isNightCoffee(coffee.dateTime)
+                              ? "bg-amber-400/15 text-amber-400"
+                              : "bg-sky-400/15 text-sky-400"
+                          }`}
+                        >
+                          {isNightCoffee(coffee.dateTime) ? "Noturno" : "Diurno"}
+                        </span>
+                      </div>
+                      <div className="text-right shrink-0">
+                        <p className="text-sm font-semibold text-foreground">
+                          {coffee.sold.toLocaleString("pt-BR")}
+                        </p>
+                        <p className="text-xs text-muted-foreground">vendidos</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
         )}
       </CardContent>

--- a/new-site/packages/front-backoffice/src/pages/Dashboard/components/KitsCard.tsx
+++ b/new-site/packages/front-backoffice/src/pages/Dashboard/components/KitsCard.tsx
@@ -1,0 +1,128 @@
+import { useMemo, useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Shirt } from "lucide-react";
+import type { KitSalesStats } from "@/api/dashboard";
+
+type GroupMode = "color" | "size";
+
+interface KitGroup {
+  label: string;
+  total: number;
+  children: { label: string; count: number }[];
+}
+
+// Monta a árvore de agrupamento a partir da lista plana byColorAndSize do backend
+// (cor × tamanho × corte). O corte (is_babylook) não é separado no toggle; as
+// quantidades são somadas dentro do agrupamento escolhido.
+function buildGroups(data: KitSalesStats | undefined, mode: GroupMode): KitGroup[] {
+  const variants = data?.byColorAndSize ?? [];
+
+  const groups = new Map<string, Map<string, number>>();
+  for (const variant of variants) {
+    const outer = mode === "color" ? variant.color : variant.size;
+    const inner = mode === "color" ? variant.size : variant.color;
+
+    if (!groups.has(outer)) groups.set(outer, new Map());
+    const innerMap = groups.get(outer)!;
+    innerMap.set(inner, (innerMap.get(inner) ?? 0) + variant.count);
+  }
+
+  return [...groups.entries()]
+    .map(([label, innerMap]) => {
+      const children = [...innerMap.entries()]
+        .map(([label, count]) => ({ label, count }))
+        .sort((a, b) => b.count - a.count);
+      const total = children.reduce((sum, child) => sum + child.count, 0);
+      return { label, total, children };
+    })
+    .sort((a, b) => b.total - a.total);
+}
+
+export default function KitsCard({ data, loading }: { data?: KitSalesStats; loading: boolean }) {
+  const [mode, setMode] = useState<GroupMode>("color");
+
+  const groups = useMemo(() => buildGroups(data, mode), [data, mode]);
+
+  const outerLabel = mode === "color" ? "Cor" : "Tamanho";
+  const innerLabel = mode === "color" ? "Tamanho" : "Cor";
+
+  return (
+    <Card className="border-border bg-card/80 rounded-2xl transition-colors hover:border-primary/40">
+      <CardHeader>
+        <div className="mb-1 flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <span className="rounded-lg bg-primary/15 p-2 text-primary">
+              <Shirt className="w-5 h-5" />
+            </span>
+            <CardTitle>Vendas de kits</CardTitle>
+          </div>
+
+          <div className="flex rounded-lg border border-border bg-muted/20 p-0.5 text-xs">
+            {(["color", "size"] as GroupMode[]).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => setMode(m)}
+                className={`rounded-md px-2.5 py-1 font-medium transition-colors ${
+                  mode === m
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {m === "color" ? "Por cor" : "Por tamanho"}
+              </button>
+            ))}
+          </div>
+        </div>
+        <CardDescription>
+          Quantidade vendida agrupada por {outerLabel.toLowerCase()}.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <p className="text-sm text-muted-foreground">Carregando...</p>
+          </div>
+        ) : groups.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">Sem dados de kits vendidos.</p>
+        ) : (
+          <div className="space-y-3 max-h-96 overflow-y-auto pr-1">
+            {groups.map((group) => (
+              <div key={group.label} className="rounded-xl border border-border/50 bg-muted/20 p-3">
+                <div className="mb-2 flex items-center justify-between">
+                  <p className="text-sm font-semibold text-foreground">{group.label}</p>
+                  <span className="rounded-full bg-primary/15 px-2 py-0.5 text-xs font-medium text-primary">
+                    {group.total.toLocaleString("pt-BR")} no total
+                  </span>
+                </div>
+
+                <div className="space-y-1.5">
+                  {group.children.map((child) => {
+                    const width = group.total > 0 ? (child.count / group.total) * 100 : 0;
+                    return (
+                      <div key={child.label} className="flex items-center gap-2">
+                        <span className="w-24 shrink-0 text-xs text-muted-foreground">
+                          {innerLabel}: {child.label}
+                        </span>
+                        <div className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+                          <div
+                            className="h-full rounded-full bg-primary/60"
+                            style={{ width: `${width}%` }}
+                          />
+                        </div>
+                        <span className="w-12 shrink-0 text-right text-xs font-medium text-foreground">
+                          {child.count.toLocaleString("pt-BR")}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/new-site/packages/front-backoffice/src/pages/Dashboard/components/OverviewCard.tsx
+++ b/new-site/packages/front-backoffice/src/pages/Dashboard/components/OverviewCard.tsx
@@ -1,0 +1,67 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Users } from "lucide-react";
+import type { UsersStats } from "@/api/dashboard";
+
+interface OverviewCardProps {
+  data?: UsersStats;
+  loading: boolean;
+}
+
+function formatNumber(value: number | undefined): string {
+  return (value ?? 0).toLocaleString("pt-BR");
+}
+
+export default function OverviewCard({ data, loading }: OverviewCardProps) {
+  const stats = [
+    {
+      label: "Inscritos",
+      value: formatNumber(data?.total),
+      accent: "text-sky-400",
+    },
+    {
+      label: "Justificados de ausência",
+      value: formatNumber(data?.justifiedAbsence),
+      accent: "text-amber-400",
+    },
+    {
+      label: "Com PAPFE",
+      value: formatNumber(data?.totalWithPapfe),
+      accent: "text-emerald-400",
+    },
+  ];
+
+  return (
+    <Card className="border-border bg-card/80 rounded-2xl transition-colors hover:border-primary/40">
+      <CardHeader>
+        <div className="mb-1 flex items-center gap-2">
+          <span className="rounded-lg bg-primary/15 p-2 text-primary">
+            <Users className="w-5 h-5" />
+          </span>
+          <CardTitle>Overview de participantes</CardTitle>
+        </div>
+        <CardDescription>Inscritos, justificados de ausência e alunos com PAPFE.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <p className="text-sm text-muted-foreground">Carregando...</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            {stats.map((stat) => (
+              <div
+                key={stat.label}
+                className="rounded-xl border border-border/50 bg-muted/20 p-4 text-center"
+              >
+                <p className={`text-2xl md:text-3xl font-bold ${stat.accent}`}>{stat.value}</p>
+                <p className="mt-1 text-xs uppercase tracking-wide text-muted-foreground">
+                  {stat.label}
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/new-site/packages/front-backoffice/src/pages/Dashboard/components/OverviewCard.tsx
+++ b/new-site/packages/front-backoffice/src/pages/Dashboard/components/OverviewCard.tsx
@@ -30,6 +30,12 @@ export default function OverviewCard({ data, loading }: OverviewCardProps) {
     },
   ];
 
+  const usp = data?.uspParticipants ?? 0;
+  const external = data?.externalParticipants ?? 0;
+  const originTotal = usp + external;
+  const uspPercent = originTotal > 0 ? (usp / originTotal) * 100 : 0;
+  const externalPercent = originTotal > 0 ? (external / originTotal) * 100 : 0;
+
   return (
     <Card className="border-border bg-card/80 rounded-2xl transition-colors hover:border-primary/40">
       <CardHeader>
@@ -39,7 +45,9 @@ export default function OverviewCard({ data, loading }: OverviewCardProps) {
           </span>
           <CardTitle>Overview de participantes</CardTitle>
         </div>
-        <CardDescription>Inscritos, justificados de ausência e alunos com PAPFE.</CardDescription>
+        <CardDescription>
+          Inscritos, justificados de ausência e alunos com PAPFE. Origem: USP × externos.
+        </CardDescription>
       </CardHeader>
       <CardContent>
         {loading ? (
@@ -47,18 +55,50 @@ export default function OverviewCard({ data, loading }: OverviewCardProps) {
             <p className="text-sm text-muted-foreground">Carregando...</p>
           </div>
         ) : (
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-            {stats.map((stat) => (
-              <div
-                key={stat.label}
-                className="rounded-xl border border-border/50 bg-muted/20 p-4 text-center"
-              >
-                <p className={`text-2xl md:text-3xl font-bold ${stat.accent}`}>{stat.value}</p>
-                <p className="mt-1 text-xs uppercase tracking-wide text-muted-foreground">
-                  {stat.label}
-                </p>
+          <div className="space-y-3">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              {stats.map((stat) => (
+                <div
+                  key={stat.label}
+                  className="rounded-xl border border-border/50 bg-muted/20 p-4 text-center"
+                >
+                  <p className={`text-2xl md:text-3xl font-bold ${stat.accent}`}>{stat.value}</p>
+                  <p className="mt-1 text-xs uppercase tracking-wide text-muted-foreground">
+                    {stat.label}
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            <div className="rounded-xl border border-border/50 bg-muted/20 p-4">
+              <div className="mb-2 flex items-center justify-between">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">Origem</p>
+                <div className="flex items-center gap-3 text-xs">
+                  <span className="flex items-center gap-1.5 font-medium text-sky-400">
+                    <span className="h-2 w-2 rounded-full bg-sky-400" />
+                    USP · {formatNumber(usp)} ({uspPercent.toFixed(1).replace(".", ",")}%)
+                  </span>
+                  <span className="flex items-center gap-1.5 font-medium text-violet-400">
+                    <span className="h-2 w-2 rounded-full bg-violet-400" />
+                    Externos · {formatNumber(external)} ({externalPercent.toFixed(1).replace(".", ",")}%)
+                  </span>
+                </div>
               </div>
-            ))}
+              {originTotal > 0 ? (
+                <div className="flex h-2.5 w-full overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full bg-sky-400 transition-all"
+                    style={{ width: `${uspPercent}%` }}
+                  />
+                  <div
+                    className="h-full bg-violet-400 transition-all"
+                    style={{ width: `${externalPercent}%` }}
+                  />
+                </div>
+              ) : (
+                <p className="py-1 text-center text-xs text-muted-foreground">Sem dados de origem.</p>
+              )}
+            </div>
           </div>
         )}
       </CardContent>

--- a/new-site/packages/front-backoffice/src/pages/Dashboard/components/PresenceCard.tsx
+++ b/new-site/packages/front-backoffice/src/pages/Dashboard/components/PresenceCard.tsx
@@ -1,0 +1,85 @@
+import { useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Presentation, ArrowRight } from "lucide-react";
+import type { EventsSummary } from "@/api/dashboard";
+
+export default function PresenceCard({
+  data,
+  loading,
+}: {
+  data?: EventsSummary;
+  loading: boolean;
+}) {
+  const navigate = useNavigate();
+
+  const stats = useMemo(() => {
+    const events = data?.events ?? [];
+    const present = events.reduce((acc, e) => acc + e.present, 0);
+    const total = events.reduce((acc, e) => acc + e.total, 0);
+    const rate = total > 0 ? (present / total) * 100 : 0;
+    return { events: events.length, present, rate };
+  }, [data]);
+
+  const items = [
+    { label: "Eventos", value: stats.events.toLocaleString("pt-BR") },
+    { label: "Presenças", value: stats.present.toLocaleString("pt-BR") },
+    { label: "Taxa média", value: `${stats.rate.toFixed(1)}%` },
+  ];
+
+  return (
+    <Card className="border-border bg-card/80 rounded-2xl transition-colors hover:border-primary/40">
+      <CardHeader>
+        <div className="mb-1 flex items-center gap-2">
+          <span className="rounded-lg bg-primary/15 p-2 text-primary">
+            <Presentation className="w-5 h-5" />
+          </span>
+          <CardTitle>Presença em eventos</CardTitle>
+        </div>
+        <CardDescription>Presenças, taxa média e análise detalhada por evento.</CardDescription>
+      </CardHeader>
+
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <p className="text-sm text-muted-foreground">Carregando...</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-3 gap-2">
+            {items.map((stat) => (
+              <div
+                key={stat.label}
+                className="rounded-lg border border-border/50 bg-muted/20 p-3 text-center"
+              >
+                <p className="text-xl font-bold text-primary">{stat.value}</p>
+                <p className="mt-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+                  {stat.label}
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+
+      <CardFooter>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full gap-2 text-muted-foreground hover:text-foreground"
+          onClick={() => navigate("/dashboard/presence")}
+        >
+          Ver análise de presença
+          <ArrowRight className="w-3.5 h-3.5" />
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/new-site/packages/front-backoffice/src/pages/Dashboard/components/ProductsCard.tsx
+++ b/new-site/packages/front-backoffice/src/pages/Dashboard/components/ProductsCard.tsx
@@ -1,0 +1,147 @@
+import { useMemo, useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ShoppingBag } from "lucide-react";
+import type { SalesOverviewStats } from "@/api/dashboard";
+
+type SortMode = "sold" | "revenue";
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  }).format(value);
+}
+
+export default function ProductsCard({
+  data,
+  loading,
+}: {
+  data?: SalesOverviewStats;
+  loading: boolean;
+}) {
+  const [mode, setMode] = useState<SortMode>("sold");
+
+  const ranked = useMemo(() => {
+    const products = data?.topProducts ?? [];
+    return [...products].sort((a, b) => b[mode] - a[mode]);
+  }, [data, mode]);
+
+  const maxValue = ranked.length > 0 ? ranked[0][mode] : 0;
+
+  const tiles = [
+    { label: "Pagos", value: (data?.totalPaid ?? 0).toLocaleString("pt-BR") },
+    { label: "Pendentes", value: (data?.totalPending ?? 0).toLocaleString("pt-BR") },
+    { label: "Faturamento", value: formatCurrency(data?.totalRevenue ?? 0) },
+  ];
+
+  return (
+    <Card className="border-border bg-card/80 rounded-2xl transition-colors hover:border-primary/40">
+      <CardHeader>
+        <div className="mb-1 flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <span className="rounded-lg bg-primary/15 p-2 text-primary">
+              <ShoppingBag className="w-5 h-5" />
+            </span>
+            <CardTitle>Compras e produtos</CardTitle>
+          </div>
+
+          <div className="flex rounded-lg border border-border bg-muted/20 p-0.5 text-xs">
+            {(["sold", "revenue"] as SortMode[]).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => setMode(m)}
+                className={`rounded-md px-2.5 py-1 font-medium transition-colors ${
+                  mode === m
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {m === "sold" ? "Mais vendidos" : "Maior valor"}
+              </button>
+            ))}
+          </div>
+        </div>
+        <CardDescription>
+          Quantidade, faturamento e ranking de itens vendidos (pedidos PAGO).
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <p className="text-sm text-muted-foreground">Carregando...</p>
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-3 gap-2">
+              {tiles.map((stat) => (
+                <div
+                  key={stat.label}
+                  className="rounded-lg border border-border/50 bg-muted/20 p-3 text-center"
+                >
+                  <p className="text-base md:text-lg font-bold text-primary">{stat.value}</p>
+                  <p className="mt-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+                    {stat.label}
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            {ranked.length === 0 ? null : (
+              <div className="mt-4 space-y-2 max-h-96 overflow-y-auto pr-1">
+                {ranked.map((product, index) => {
+                  const width = maxValue > 0 ? (product[mode] / maxValue) * 100 : 0;
+                  return (
+                    <div
+                      key={product.productId}
+                      className="rounded-xl border border-border/50 bg-muted/20 p-3"
+                    >
+                      <div className="mb-2 flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-2">
+                          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">
+                            {index + 1}º
+                          </span>
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-semibold text-foreground">
+                              {product.name}
+                            </p>
+                            <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium uppercase text-primary">
+                              {product.type}
+                            </span>
+                          </div>
+                        </div>
+                        <div className="shrink-0 text-right">
+                          <p className="text-sm font-bold text-foreground">
+                            {mode === "sold"
+                              ? product.sold.toLocaleString("pt-BR")
+                              : formatCurrency(product.revenue)}
+                          </p>
+                          {mode === "sold" ? (
+                            <p className="text-[11px] text-muted-foreground">
+                              {formatCurrency(product.revenue)}
+                            </p>
+                          ) : (
+                            <p className="text-[11px] text-muted-foreground">
+                              {product.sold.toLocaleString("pt-BR")} vendidos
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                      <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                        <div
+                          className="h-full rounded-full bg-primary/50"
+                          style={{ width: `${width}%` }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/new-site/packages/front-backoffice/src/pages/Dashboard/components/presenceUtils.ts
+++ b/new-site/packages/front-backoffice/src/pages/Dashboard/components/presenceUtils.ts
@@ -1,0 +1,19 @@
+import type { EventStats } from "@/api/dashboard";
+
+// Agrupa eventos por dia usando a parte de data (UTC) de eventDate.
+export function getEventDay(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+export function formatDayLabel(iso: string): string {
+  const [y, m, d] = iso.slice(0, 10).split("-").map(Number);
+  return new Date(y, m - 1, d).toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
+export function listDays(events: EventStats[]): string[] {
+  return [...new Set(events.map((e) => getEventDay(e.eventDate)))].sort();
+}

--- a/new-site/packages/front-backoffice/src/pages/Dashboard/index.tsx
+++ b/new-site/packages/front-backoffice/src/pages/Dashboard/index.tsx
@@ -1,0 +1,76 @@
+import { useNavigate } from "react-router-dom";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { BannerCard } from "@/components/BannerCard";
+import { Tabs } from "@/constants/Tabs";
+import { Users, Shirt, Coffee, Presentation, ShoppingBag } from "lucide-react";
+
+const Sections = [
+  {
+    key: "overview",
+    title: "Overview de participantes",
+    description: "Nº de inscritos, justificados de ausência e alunos com PAPFE.",
+    icon: <Users className="w-5 h-5" />,
+  },
+  {
+    key: "kits",
+    title: "Vendas de kits",
+    description: "Quantidade vendida por tamanho e cor.",
+    icon: <Shirt className="w-5 h-5" />,
+  },
+  {
+    key: "coffees",
+    title: "Coffes vendidos",
+    description: "Quantidade total de coffes vendidos.",
+    icon: <Coffee className="w-5 h-5" />,
+  },
+  {
+    key: "presence",
+    title: "Presença em palestras",
+    description: "Comparativo de presença entre as palestras.",
+    icon: <Presentation className="w-5 h-5" />,
+  },
+  {
+    key: "products",
+    title: "Compras e produtos",
+    description: "Quantidade, faturamento e ranking de itens vendidos.",
+    icon: <ShoppingBag className="w-5 h-5" />,
+  },
+];
+
+export default function DashboardPage() {
+  const navigate = useNavigate();
+
+  return (
+    <section className="mx-auto w-full max-w-7xl px-4 py-8 md:px-6 md:py-10 space-y-8">
+      <BannerCard
+        icon={Tabs.find((t) => t.key === "dashboard")?.icon}
+        iconClassName="text-sky-400"
+        label="Dados"
+        title="Dashboard de Dados"
+        description="Métricas e dados da Semcomp em uma só tela, agrupados por tema."
+        onBack={() => navigate("/home")}
+        cardClassName="border-slate-800 bg-linear-to-br from-slate-900 via-slate-900 to-sky-950/40 overflow-hidden relative"
+        labelClassName="text-xs uppercase tracking-[0.3em] text-sky-400 font-medium"
+        titleClassName="text-2xl md:text-3xl text-white font-semibold"
+        descriptionClassName="text-slate-400 mt-1"
+      />
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {Sections.map((section) => (
+          <Card
+            key={section.key}
+            className="border-border bg-card/80 rounded-2xl transition-colors hover:border-primary/40"
+          >
+            <CardHeader>
+              <div className="mb-1 flex items-center gap-2">
+                <span className="rounded-lg bg-primary/15 p-2 text-primary">{section.icon}</span>
+                <CardTitle>{section.title}</CardTitle>
+              </div>
+              <CardDescription>{section.description}</CardDescription>
+            </CardHeader>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/new-site/packages/front-backoffice/src/pages/Dashboard/index.tsx
+++ b/new-site/packages/front-backoffice/src/pages/Dashboard/index.tsx
@@ -3,20 +3,15 @@ import { useNavigate } from "react-router-dom";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { BannerCard } from "@/components/BannerCard";
 import { Tabs } from "@/constants/Tabs";
-import { Presentation, ShoppingBag } from "lucide-react";
+import { ShoppingBag } from "lucide-react";
 import { dashboardAPI } from "@/api/dashboard";
 import type { DashboardResponse } from "@/api/dashboard";
 import OverviewCard from "./components/OverviewCard";
 import KitsCard from "./components/KitsCard";
 import CoffeesCard from "./components/CoffeesCard";
+import PresenceCard from "./components/PresenceCard";
 
 const PlaceholderSections = [
-  {
-    key: "presence",
-    title: "Presença em palestras",
-    description: "Comparativo de presença entre as palestras.",
-    icon: <Presentation className="w-5 h-5" />,
-  },
   {
     key: "products",
     title: "Compras e produtos",
@@ -78,6 +73,7 @@ export default function DashboardPage() {
         <OverviewCard data={data?.users} loading={loading && !data} />
         <KitsCard data={data?.kits} loading={loading && !data} />
         <CoffeesCard data={data?.coffees} loading={loading && !data} />
+        <PresenceCard data={data?.events} loading={loading && !data} />
 
         {PlaceholderSections.map((section) => (
           <Card

--- a/new-site/packages/front-backoffice/src/pages/Dashboard/index.tsx
+++ b/new-site/packages/front-backoffice/src/pages/Dashboard/index.tsx
@@ -1,16 +1,14 @@
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { BannerCard } from "@/components/BannerCard";
 import { Tabs } from "@/constants/Tabs";
-import { Users, Shirt, Coffee, Presentation, ShoppingBag } from "lucide-react";
+import { Shirt, Coffee, Presentation, ShoppingBag } from "lucide-react";
+import { dashboardAPI } from "@/api/dashboard";
+import type { DashboardResponse } from "@/api/dashboard";
+import OverviewCard from "./components/OverviewCard";
 
-const Sections = [
-  {
-    key: "overview",
-    title: "Overview de participantes",
-    description: "Nº de inscritos, justificados de ausência e alunos com PAPFE.",
-    icon: <Users className="w-5 h-5" />,
-  },
+const PlaceholderSections = [
   {
     key: "kits",
     title: "Vendas de kits",
@@ -40,6 +38,33 @@ const Sections = [
 export default function DashboardPage() {
   const navigate = useNavigate();
 
+  const [data, setData] = useState<DashboardResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchDashboard = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await dashboardAPI.get();
+        if (!cancelled) setData(response);
+      } catch {
+        if (!cancelled) setError("Erro ao carregar os dados do dashboard");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchDashboard();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <section className="mx-auto w-full max-w-7xl px-4 py-8 md:px-6 md:py-10 space-y-8">
       <BannerCard
@@ -55,8 +80,14 @@ export default function DashboardPage() {
         descriptionClassName="text-slate-400 mt-1"
       />
 
+      {error && (
+        <div className="rounded-lg bg-red-900/20 border border-red-700 p-4 text-red-200">{error}</div>
+      )}
+
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-        {Sections.map((section) => (
+        <OverviewCard data={data?.users} loading={loading && !data} />
+
+        {PlaceholderSections.map((section) => (
           <Card
             key={section.key}
             className="border-border bg-card/80 rounded-2xl transition-colors hover:border-primary/40"

--- a/new-site/packages/front-backoffice/src/pages/Dashboard/index.tsx
+++ b/new-site/packages/front-backoffice/src/pages/Dashboard/index.tsx
@@ -1,24 +1,14 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { BannerCard } from "@/components/BannerCard";
 import { Tabs } from "@/constants/Tabs";
-import { ShoppingBag } from "lucide-react";
 import { dashboardAPI } from "@/api/dashboard";
 import type { DashboardResponse } from "@/api/dashboard";
 import OverviewCard from "./components/OverviewCard";
 import KitsCard from "./components/KitsCard";
 import CoffeesCard from "./components/CoffeesCard";
 import PresenceCard from "./components/PresenceCard";
-
-const PlaceholderSections = [
-  {
-    key: "products",
-    title: "Compras e produtos",
-    description: "Quantidade, faturamento e ranking de itens vendidos.",
-    icon: <ShoppingBag className="w-5 h-5" />,
-  },
-];
+import ProductsCard from "./components/ProductsCard";
 
 export default function DashboardPage() {
   const navigate = useNavigate();
@@ -74,21 +64,7 @@ export default function DashboardPage() {
         <KitsCard data={data?.kits} loading={loading && !data} />
         <CoffeesCard data={data?.coffees} loading={loading && !data} />
         <PresenceCard data={data?.events} loading={loading && !data} />
-
-        {PlaceholderSections.map((section) => (
-          <Card
-            key={section.key}
-            className="border-border bg-card/80 rounded-2xl transition-colors hover:border-primary/40"
-          >
-            <CardHeader>
-              <div className="mb-1 flex items-center gap-2">
-                <span className="rounded-lg bg-primary/15 p-2 text-primary">{section.icon}</span>
-                <CardTitle>{section.title}</CardTitle>
-              </div>
-              <CardDescription>{section.description}</CardDescription>
-            </CardHeader>
-          </Card>
-        ))}
+        <ProductsCard data={data?.sales} loading={loading && !data} />
       </div>
     </section>
   );

--- a/new-site/packages/front-backoffice/src/pages/Dashboard/index.tsx
+++ b/new-site/packages/front-backoffice/src/pages/Dashboard/index.tsx
@@ -3,18 +3,13 @@ import { useNavigate } from "react-router-dom";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { BannerCard } from "@/components/BannerCard";
 import { Tabs } from "@/constants/Tabs";
-import { Shirt, Coffee, Presentation, ShoppingBag } from "lucide-react";
+import { Coffee, Presentation, ShoppingBag } from "lucide-react";
 import { dashboardAPI } from "@/api/dashboard";
 import type { DashboardResponse } from "@/api/dashboard";
 import OverviewCard from "./components/OverviewCard";
+import KitsCard from "./components/KitsCard";
 
 const PlaceholderSections = [
-  {
-    key: "kits",
-    title: "Vendas de kits",
-    description: "Quantidade vendida por tamanho e cor.",
-    icon: <Shirt className="w-5 h-5" />,
-  },
   {
     key: "coffees",
     title: "Coffes vendidos",
@@ -86,6 +81,7 @@ export default function DashboardPage() {
 
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
         <OverviewCard data={data?.users} loading={loading && !data} />
+        <KitsCard data={data?.kits} loading={loading && !data} />
 
         {PlaceholderSections.map((section) => (
           <Card

--- a/new-site/packages/front-backoffice/src/pages/Dashboard/index.tsx
+++ b/new-site/packages/front-backoffice/src/pages/Dashboard/index.tsx
@@ -3,19 +3,14 @@ import { useNavigate } from "react-router-dom";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { BannerCard } from "@/components/BannerCard";
 import { Tabs } from "@/constants/Tabs";
-import { Coffee, Presentation, ShoppingBag } from "lucide-react";
+import { Presentation, ShoppingBag } from "lucide-react";
 import { dashboardAPI } from "@/api/dashboard";
 import type { DashboardResponse } from "@/api/dashboard";
 import OverviewCard from "./components/OverviewCard";
 import KitsCard from "./components/KitsCard";
+import CoffeesCard from "./components/CoffeesCard";
 
 const PlaceholderSections = [
-  {
-    key: "coffees",
-    title: "Coffes vendidos",
-    description: "Quantidade total de coffes vendidos.",
-    icon: <Coffee className="w-5 h-5" />,
-  },
   {
     key: "presence",
     title: "Presença em palestras",
@@ -82,6 +77,7 @@ export default function DashboardPage() {
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
         <OverviewCard data={data?.users} loading={loading && !data} />
         <KitsCard data={data?.kits} loading={loading && !data} />
+        <CoffeesCard data={data?.coffees} loading={loading && !data} />
 
         {PlaceholderSections.map((section) => (
           <Card

--- a/new-site/packages/front-backoffice/src/pages/Dashboard/presence.tsx
+++ b/new-site/packages/front-backoffice/src/pages/Dashboard/presence.tsx
@@ -1,0 +1,294 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { BannerCard } from "@/components/BannerCard";
+import { Tabs } from "@/constants/Tabs";
+import { Presentation } from "lucide-react";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Cell,
+  LabelList,
+} from "recharts";
+import type { TooltipContentProps } from "recharts";
+import { dashboardAPI } from "@/api/dashboard";
+import type { EventStats } from "@/api/dashboard";
+import { listDays, formatDayLabel, getEventDay } from "./components/presenceUtils";
+
+type Metric = "present" | "rate";
+
+const BAR_COLORS = ["#38bdf8", "#a78bfa", "#34d399", "#fbbf24", "#f472b6", "#fb7185", "#818cf8"];
+
+interface PresenceDatum {
+  name: string;
+  present: number;
+  total: number;
+  rate: number;
+}
+
+type PresenceTooltipProps = Pick<TooltipContentProps<number, string>, "active" | "payload" | "label">;
+
+function PresenceTooltip({ active, payload, label }: PresenceTooltipProps) {
+  if (!active || !payload?.length) return null;
+
+  const datum = payload[0].payload as PresenceDatum;
+
+  return (
+    <div className="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-xs shadow-lg">
+      <p className="font-semibold text-slate-100">{label}</p>
+      <p className="mt-1 text-slate-300">
+        Presenças: <span className="font-medium text-slate-100">{datum.present}</span>
+      </p>
+      <p className="text-slate-300">
+        Inscritos: <span className="font-medium text-slate-100">{datum.total}</span>
+      </p>
+      <p className="text-slate-300">
+        Taxa: <span className="font-medium text-sky-300">{datum.rate.toFixed(1)}%</span>
+      </p>
+    </div>
+  );
+}
+
+export default function PresencePage() {
+  const navigate = useNavigate();
+
+  const [events, setEvents] = useState<EventStats[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [day, setDay] = useState<string>("all");
+  const [metric, setMetric] = useState<Metric>("present");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchEvents = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await dashboardAPI.get({ sections: ["events"] });
+        if (!cancelled) setEvents(response.events?.events ?? []);
+      } catch {
+        if (!cancelled) setError("Erro ao carregar os dados de presença");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchEvents();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const days = useMemo(() => listDays(events), [events]);
+
+  const filtered = useMemo(() => {
+    if (day === "all") return events;
+    return events.filter((e) => getEventDay(e.eventDate) === day);
+  }, [events, day]);
+
+  const chartData = useMemo<PresenceDatum[]>(
+    () =>
+      filtered
+        .map((e) => ({
+          name: e.eventName,
+          present: e.present,
+          total: e.total,
+          rate: e.total > 0 ? (e.present / e.total) * 100 : 0,
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [filtered]
+  );
+
+  const totals = useMemo(
+    () =>
+      chartData.reduce(
+        (acc, e) => ({ present: acc.present + e.present, total: acc.total + e.total }),
+        { present: 0, total: 0 }
+      ),
+    [chartData]
+  );
+
+  const meanRate = totals.total > 0 ? (totals.present / totals.total) * 100 : 0;
+
+  return (
+    <section className="mx-auto w-full max-w-7xl px-4 py-8 md:px-6 md:py-10 space-y-6">
+      <BannerCard
+        icon={Tabs.find((t) => t.key === "dashboard")?.icon}
+        iconClassName="text-sky-400"
+        label="Dados"
+        title="Análise de Presença"
+        description="Compare a presença entre os eventos, filtrando por dia."
+        onBack={() => navigate("/dashboard")}
+        cardClassName="border-slate-800 bg-linear-to-br from-slate-900 via-slate-900 to-sky-950/40 overflow-hidden relative"
+        labelClassName="text-xs uppercase tracking-[0.3em] text-sky-400 font-medium"
+        titleClassName="text-2xl md:text-3xl text-white font-semibold"
+        descriptionClassName="text-slate-400 mt-1"
+      />
+
+      {error && (
+        <div className="rounded-lg bg-red-900/20 border border-red-700 p-4 text-red-200">{error}</div>
+      )}
+
+      {/* Filtro por dia + toggle de métrica */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => setDay("all")}
+            className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
+              day === "all"
+                ? "border-primary/40 bg-primary/30 text-primary"
+                : "border-border bg-muted/20 text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Todos os dias
+          </button>
+          {days.map((d) => (
+            <button
+              key={d}
+              type="button"
+              onClick={() => setDay(d)}
+              className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
+                day === d
+                  ? "border-primary/40 bg-primary/30 text-primary"
+                  : "border-border bg-muted/20 text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {formatDayLabel(d)}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex rounded-lg border border-border bg-muted/20 p-0.5 text-xs">
+          {(["present", "rate"] as Metric[]).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMetric(m)}
+              className={`rounded-md px-2.5 py-1 font-medium transition-colors ${
+                metric === m
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {m === "present" ? "Presenças" : "Taxa (%)"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Resumo */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        {[
+          { label: "Eventos", value: chartData.length.toLocaleString("pt-BR") },
+          { label: "Presenças", value: totals.present.toLocaleString("pt-BR") },
+          { label: "Taxa média", value: `${meanRate.toFixed(1)}%` },
+        ].map((stat) => (
+          <div key={stat.label} className="rounded-xl border border-border/50 bg-muted/20 p-4 text-center">
+            <p className="text-2xl font-bold text-primary">{stat.value}</p>
+            <p className="mt-1 text-xs uppercase tracking-wide text-muted-foreground">{stat.label}</p>
+          </div>
+        ))}
+      </div>
+
+      <Card className="border-border bg-card/80 rounded-2xl">
+        <CardHeader>
+          <div className="mb-1 flex items-center gap-2">
+            <span className="rounded-lg bg-primary/15 p-2 text-primary">
+              <Presentation className="w-5 h-5" />
+            </span>
+            <CardTitle>
+              {day === "all" ? "Todos os eventos" : `Eventos de ${formatDayLabel(day)}`}
+            </CardTitle>
+            <CardDescription className="ml-auto hidden sm:block">
+              {metric === "present" ? "Nº de presenças por evento" : "Taxa de presença por evento"}
+            </CardDescription>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex items-center justify-center py-16">
+              <p className="text-sm text-muted-foreground">Carregando...</p>
+            </div>
+          ) : chartData.length === 0 ? (
+            <p className="py-16 text-center text-sm text-muted-foreground">
+              Nenhum evento para o filtro selecionado.
+            </p>
+          ) : (
+            <div className="h-96 w-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={chartData} margin={{ top: 16, right: 8, left: 4, bottom: 8 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.2)" vertical={false} />
+                  <XAxis
+                    dataKey="name"
+                    tick={{ fill: "#94a3b8", fontSize: 11 }}
+                    axisLine={false}
+                    tickLine={false}
+                    interval={0}
+                    angle={-20}
+                    textAnchor="end"
+                    height={52}
+                  />
+                  <YAxis
+                    tick={{ fill: "#94a3b8", fontSize: 11 }}
+                    axisLine={false}
+                    tickLine={false}
+                    allowDecimals={false}
+                    domain={metric === "rate" ? [0, 100] : undefined}
+                    unit={metric === "rate" ? "%" : undefined}
+                  />
+                  <Tooltip
+                    cursor={{ fill: "rgba(148,163,184,0.1)" }}
+                    content={({ active, payload, label }) => (
+                      <PresenceTooltip active={active} payload={payload} label={label} />
+                    )}
+                  />
+                  {metric === "present" ? (
+                    <Bar name="Presenças" dataKey="present" radius={[6, 6, 0, 0]}>
+                      {chartData.map((_, index) => (
+                        <Cell key={index} fill={BAR_COLORS[index % BAR_COLORS.length]} />
+                      ))}
+                      <LabelList
+                        dataKey="present"
+                        position="top"
+                        offset={6}
+                        fontSize={11}
+                        fill="#cbd5e1"
+                        formatter={(value) =>
+                          typeof value === "number" ? String(value) : String(value)
+                        }
+                      />
+                    </Bar>
+                  ) : (
+                    <Bar name="Taxa (%)" dataKey="rate" radius={[6, 6, 0, 0]}>
+                      {chartData.map((_, index) => (
+                        <Cell key={index} fill={BAR_COLORS[index % BAR_COLORS.length]} />
+                      ))}
+                      <LabelList
+                        dataKey="rate"
+                        position="top"
+                        offset={6}
+                        fontSize={11}
+                        fill="#cbd5e1"
+                        formatter={(value) =>
+                          typeof value === "number" ? `${value.toFixed(0)}%` : `${value}%`
+                        }
+                      />
+                    </Bar>
+                  )}
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/new-site/packages/front-backoffice/src/pages/Permission/index.tsx
+++ b/new-site/packages/front-backoffice/src/pages/Permission/index.tsx
@@ -46,6 +46,7 @@ const SECTIONS: { key: string; label: string }[] = [
   { key: "Justificativas de Ausência",  label: "Justificativas de Ausência" },
   { key: "Produtos",       label: "Produtos" },
   { key: "Avisos", label: "Avisos" },
+  { key: "Dashboard", label: "Dados" }
 ];
 
 type PermLevel = "R" | "RW" | "—";

--- a/new-site/packages/front-backoffice/src/routes/Routes.tsx
+++ b/new-site/packages/front-backoffice/src/routes/Routes.tsx
@@ -18,6 +18,7 @@ import PapfeDocuments from "@/pages/PapfeDocuments";
 import NoticesCRUD from "@/pages/Notices"
 import AbsenceJustifications from "@/pages/AbsenceJustifications";
 import DashboardPage from "@/pages/Dashboard";
+import PresencePage from "@/pages/Dashboard/presence";
 import NotFoundPage from "@/pages/NotFound";
 
 export const router = createBrowserRouter(
@@ -94,7 +95,10 @@ export const router = createBrowserRouter(
             },
             {
               element: <RequirePermission section="Dashboard" />,
-              children: [{ path: "/dashboard", element: <DashboardPage /> }],
+              children: [
+                { path: "/dashboard", element: <DashboardPage /> },
+                { path: "/dashboard/presence", element: <PresencePage /> },
+              ],
             },
             {
               path: "*",

--- a/new-site/packages/front-backoffice/src/routes/Routes.tsx
+++ b/new-site/packages/front-backoffice/src/routes/Routes.tsx
@@ -17,6 +17,7 @@ import SalesCRUD from "@/pages/Sales";
 import PapfeDocuments from "@/pages/PapfeDocuments";
 import NoticesCRUD from "@/pages/Notices"
 import AbsenceJustifications from "@/pages/AbsenceJustifications";
+import DashboardPage from "@/pages/Dashboard";
 import NotFoundPage from "@/pages/NotFound";
 
 export const router = createBrowserRouter(
@@ -90,6 +91,10 @@ export const router = createBrowserRouter(
             {
               element: <RequirePermission section="Justificativas de Ausência" />,
               children: [{ path: "/absence-justifications", element: <AbsenceJustifications /> }],
+            },
+            {
+              element: <RequirePermission section="Dashboard" />,
+              children: [{ path: "/dashboard", element: <DashboardPage /> }],
             },
             {
               path: "*",


### PR DESCRIPTION
Implementa o Dashboard de Dados no backoffice, permitindo que a administração visualize métricas e informações da Semcomp em uma única tela. Os dados são computados por queries de agregação SQL nas tabelas já existentes.

Backend:
Criado o módulo "dashboardbackoffice" (model, repository, service, handler). Faz uso das seguintes seções:
- Users -> inscritos, confirmados, com PAPFE, justificativas de ausência e média de presença
- Events -> inscrições, presenças e taxa por evento; contagem por tipo
- Kits -> vendas de camisetas por cor, tamanho, corte (BabyLook ou não) e cruzamento cor x tamanho
- Coffees -> vendas por tipo de coffee
- Combos -> vendas por combo
- Sales -> visão geral: totais por status, receita, método de pagamento, evolução temporal e ranking de produtos

Frontend:
- Página principal (/dashboard) com 5 cards: overview de participantes, vendas de kits (com toggle cor/tamanho), coffees vendidos, presença em eventos e ranking de produtos (toggle vendidos/faturamento)
- Página de análise de presença (/dashboard/presence) com gráfico de barras (Recharts), filtro por dia e toggle presenças/taxa
- API client com tipos TypeScript espelhando os DTOs do backend
- Rotas, permissões e entrada no menu lateral configurados